### PR TITLE
Fix issue in setup.cfg regarding package_dir

### DIFF
--- a/pyktest/.gitignore
+++ b/pyktest/.gitignore
@@ -121,6 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
+.pyenv
 .venv
 env/
 venv/

--- a/pyktest/setup.cfg
+++ b/pyktest/setup.cfg
@@ -16,7 +16,8 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-package_dir = pyktest
+package_dir = 
+    = pyktest
 packages = find:
 python_requires = >=3.6
 install_requires = 

--- a/pyktest/setup.cfg
+++ b/pyktest/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     # pytorch
     numpy
     scipy
-    sklearn
+    scikit-learn
     pandas
     joblib
     matplotlib


### PR DESCRIPTION
Bug introduced in PR #3 (regarding Python package file reorganization) in `setup.cfg`

Fix:
```
package_dir = 
    = pyktest
```