### PR TITLE
Implement Ktest object saving/loading

### DIFF
--- a/python/ktest/tester.py
+++ b/python/ktest/tester.py
@@ -5,6 +5,8 @@ import matplotlib.pyplot as plt
 from matplotlib import rc
 import warnings
 from tqdm import tqdm
+import dill
+import gzip
 from .kernel_statistics import Statistics
 from .data import Data
 
@@ -574,3 +576,54 @@ class Ktest(Statistics):
         ax.set_title('Projection scatter', fontsize=25)
         return(fig,ax)
 
+    def save(self, file_name, compress=True):
+        """
+        Save Ktest object to disk in binary format (pickle/dill) possibly
+        with Gzip compression.
+
+        If compression is enabled, a `.gz` extension is added to `file_name`
+        if not already present.
+
+        Parameters
+        ----------
+        file_name : str
+            absolute or relatative path to file where to store the Ktest
+            object.
+        compress : bool
+            flag to enable/disable compression when saving Ktest object to
+            disk.
+        """
+        # compress result file?
+        if compress:
+            custom_open = gzip.open
+            # add `.gz` extension if needed
+            if not file_name.endswith('.gz'):
+                file_name = file_name + '.gz'
+        else:
+            custom_open = open
+
+        with custom_open(file_name, 'wb') as f:
+            dill.dump(self, f)
+
+    @staticmethod
+    def load(file_name, compressed=True):
+        """
+        Load Ktest object that was saved on disk in binary format (pickle/dill)
+        possibly with Gzip decompression.
+
+        Parameters
+        ----------
+        file_name : str
+            absolute or relatative path to file where the Ktest object is
+            stored.
+        compressed : bool
+            flag to enable/disable decompression when loading Ktest object from
+            disk.
+        """
+        if compressed:
+            custom_open = gzip.open
+        else:
+            custom_open = open
+
+        with custom_open(file_name, 'rb') as f:
+            return dill.load(f)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,3 +45,8 @@ Homepage = "https://github.com/LMJL-Alea/ktest.git"
 [tool.setuptools]
 packages = ["ktest"]
 include-package-data = false
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0.1",
+]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+import shutil
+
+## current test dir
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+## global setup
+# output directory for tests
+pytest.output_dir = os.path.join(test_dir, "results")
+# enable/disable custom teardown and cleaning after tests
+pytest.clean = True
+
+## custom test env preparation and teardown
+@pytest.fixture(scope="session", autouse=True)
+def run_before_and_after_test_session():
+    """Custom test environment setup and teardown"""
+
+    # Before Tests
+    print(f"Creating test output directory: {pytest.output_dir}")
+    os.makedirs(pytest.output_dir, exist_ok=True)
+    assert os.path.isdir(pytest.output_dir)
+
+    # Testing
+    yield
+
+    # After tests
+    if pytest.clean:
+        print(f"Deleting test output directory: {pytest.output_dir}")
+        shutil.rmtree(pytest.output_dir)
+    else:
+        print(f"!!! Not deleting test output directory: {pytest.output_dir}")

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -1,0 +1,114 @@
+import numpy as np
+import os
+import pandas as pd
+import pytest
+import secrets
+
+from ktest.tester import Ktest
+
+
+@pytest.fixture(scope="module")
+def data_shape():
+    """Number of rows and columns in dummy data for tests."""
+    yield (1000, 100)
+
+
+@pytest.fixture(scope="module")
+def dummy_data(data_shape):
+    """Generate dummy data for testing (two groups, no difference)"""
+    # generate random data (under H0, no separation)
+    rng = np.random.default_rng()
+    data_array = rng.normal(loc=0, scale=1, size=data_shape)
+
+    # create a data frame from random gaussian data
+    data = pd.DataFrame(
+        data=data_array,
+        columns=[f"col{i+1}" for i in range(data_shape[1])]
+    )
+
+    # create meta data frame indicating two groups
+    meta = pd.Series(
+        data = [f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data, meta
+
+
+@pytest.fixture(scope="module")
+def kt(dummy_data):
+    """Create Ktest object from dummy data for testing."""
+    # init object
+    kt = Ktest(data=dummy_data[0], metadata=dummy_data[1])
+    # run kfda test
+    kt.test()
+    # output
+    yield kt
+
+
+def test_Ktest(kt, dummy_data):
+    """Testing Ktest class."""
+    # check object class
+    assert isinstance(kt, Ktest)
+
+    ## check content
+    # input data
+    for group in np.unique(dummy_data[1]):
+        np.testing.assert_equal(
+            kt.data.data[group].numpy(),
+            dummy_data[0][dummy_data[1] == group].to_numpy()
+        )
+    pd.testing.assert_series_equal(kt.metadata, dummy_data[1])
+
+    # output
+    assert isinstance(kt.kfda_statistic, pd.Series)
+    assert isinstance(kt.kfda_pval_asymp, pd.Series)
+
+
+@pytest.fixture
+def output_file():
+    """
+    Dummy file to test saving/loading.
+
+    Note: file will be removed during test teardown.
+    """
+    # add a random unique tag to file
+    yield os.path.join(pytest.output_dir, f"ktest_obj_{secrets.token_hex(4)}.pkl")
+
+
+def test_save_load(kt, output_file):
+    """Test Ktest object saving and loading."""
+    # saving (no compression)
+    kt.save(output_file, compress=False)
+    # check
+    assert os.path.isfile(output_file)
+    # saving (compression)
+    kt.save(output_file, compress=True)
+    # check
+    assert os.path.isfile(f"{output_file}.gz")
+
+    # loading (no compression)
+    kt_1 = Ktest.load(output_file, compressed=False)
+    # loading (compression)
+    kt_2 = Ktest.load(f"{output_file}.gz", compressed=True)
+
+    ## checks (compare before and after loading)
+    # input data
+    for group in np.unique(kt.metadata):
+        np.testing.assert_equal(
+            kt.data.data[group].numpy(),
+            kt_1.data.data[group].numpy()
+        )
+        np.testing.assert_equal(
+            kt.data.data[group].numpy(),
+            kt_2.data.data[group].numpy()
+        )
+    pd.testing.assert_series_equal(kt.metadata, kt_1.metadata)
+    pd.testing.assert_series_equal(kt.metadata, kt_2.metadata)
+    # test statistics
+    pd.testing.assert_series_equal(kt.kfda_statistic, kt_1.kfda_statistic)
+    pd.testing.assert_series_equal(kt.kfda_statistic, kt_2.kfda_statistic)
+    # asymptotic p-values
+    pd.testing.assert_series_equal(kt.kfda_pval_asymp, kt_1.kfda_pval_asymp)
+    pd.testing.assert_series_equal(kt.kfda_pval_asymp, kt_2.kfda_pval_asymp)
+


### PR DESCRIPTION
- implement Ktest saving to and loading from binary data file using `dill` package to pickle/unpickle it
- init unit test using `pytest` in `python/tests/` sub-dir
- implement minimal unit test for Ktest object
- implement unit test for saving and loading Ktest object