### PR TITLE
Fix median computing

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "kmeans_pytorch",
     "tqdm",
     "dill>=0.3.5.1",
+    "natsort>=8.2.0",
 ]
 
 [project.readme]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.0.10"
+version = "1.0.11"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@univ-nantes.fr"},

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -213,10 +213,17 @@ class Statistics(object):
         self.median_coef = median_coef
 
         if self.kernel_function == 'gauss':
+            if self.data_ny is not None:
+                x = self.data_ny.data[self.data.sample_names[0]]
+                y = self.data_ny.data[self.data.sample_names[1]]
+            else:
+                x = self.data.data[self.data.sample_names[0]]
+                y = self.data.data[self.data.sample_names[1]]
+
             self.kernel, self.computed_bandwidth = \
                 gauss_kernel_median(
-                    x=self.data.data[self.data.sample_names[0]],
-                    y=self.data.data[self.data.sample_names[1]],
+                    x,
+                    y,
                     bandwidth=bandwidth,
                     median_coef=median_coef,
                     return_bandwidth=True

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -118,8 +118,7 @@ def assert_equal_ktest():
                 assert group1 == group2, \
                     f"Unmatching samples '{group1}' and '{group2}'"
                 tt.assert_close(array1, array2, rtol=rtol, atol=atol)
-        else:
-            assert kt_1.data_nystrom == kt_2.data_nystrom
+
         # setup truncation
         if trunc is None:
             trunc1 = len(kt_1.kfda_statistic)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,5 @@
 from glob import glob
+from natsort import natsorted
 import numpy.testing as npt
 import os
 import pandas.testing as pdt
@@ -60,7 +61,7 @@ try:
 except ValueError:
     pass
 # sort existing files
-previous_res_files.sort()
+previous_res_files = natsorted(previous_res_files)
 # get file from previous package version to compare results
 try:
     pytest.previous_res_file = previous_res_files[-1]

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -44,9 +44,12 @@ def dummy_ktest(dummy_data):
     Function to create Ktest object from dummy data for testing using a given
     floating point number type/precision.
     """
-    def _ktest(dtype=t.float64):
+    def _ktest(nystrom=False, dtype=t.float64):
         # init object
-        kt = Ktest(data=dummy_data[0], metadata=dummy_data[1], dtype=dtype)
+        kt = Ktest(
+            data=dummy_data[0], metadata=dummy_data[1], nystrom=nystrom,
+            dtype=dtype
+        )
         # run kfda test
         kt.test()
         # output
@@ -55,10 +58,12 @@ def dummy_ktest(dummy_data):
     yield _ktest
 
 
-def test_Ktest(dummy_ktest, dummy_data):
+@pytest.mark.parametrize("nystrom", [False, True])
+@pytest.mark.parametrize("dtype", [t.float64, t.float32])
+def test_Ktest(dummy_ktest, dummy_data, nystrom, dtype):
     """Testing Ktest class."""
     # create ktest objects
-    kt = dummy_ktest()
+    kt = dummy_ktest(nystrom, dtype)
 
     # check object class
     assert isinstance(kt, Ktest)
@@ -66,9 +71,10 @@ def test_Ktest(dummy_ktest, dummy_data):
     ## check content
     # input data
     for group in np.unique(dummy_data[1]):
-        np.testing.assert_array_equal(
+        np.testing.assert_allclose(
             kt.data.data[group].numpy(),
-            dummy_data[0][dummy_data[1] == group].to_numpy()
+            dummy_data[0][dummy_data[1] == group].to_numpy(),
+            rtol=0, atol=1e-6
         )
     pd.testing.assert_series_equal(kt.metadata, dummy_data[1])
 


### PR DESCRIPTION
Bug fix: use subsampled data points to compute kernel bandwidth estimation by median instead of the whole dataset in case of Nystrom approximation (to avoid storing the full pairwise distance matrix)

Additional minor improvement:
- parametrize ktest dummy test to run with and without nystrom, using float32 or float64 precision
- use assert_allclose to compare input data and Ktest data attribute (because of floating point precision that may not be the same) instead of assert_equal
- remove nystrom data comparison if nystrom was not used in both analysis (when comparing two Ktest objects)
- use natural sorting for previous result files (so that 1.10 is after 1.9 and not before 1.2)

Version bump to 1.0.11

Note: unit test comparing current version results with results obtained by previous version is not passing (slight result difference) because the median computing slightly changed.