### PR TITLE
Fix centering matrix computing to reduce memory footprint

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,6 +50,7 @@ include-package-data = false
 
 [dependency-groups]
 dev = [
+    "ipython>=7.16.3",
     "pytest>=7.0.1",
     "toml>=0.10.2",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.0.11"
+version = "1.0.12"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@univ-nantes.fr"},

--- a/python/src/ktest/data.py
+++ b/python/src/ktest/data.py
@@ -50,11 +50,14 @@ class Data(object):
             to selecting landmarks among the observations according to the
             random uniform distribution.
 
-        random_state :  int, RandomState instance or None
+        random_state :  int, numpy.random.Generator instance,
+                numpy.random.RandomState instance or None
             Determines random number generation for the landmarks selection.
-            If None (default), the generator is the RandomState instance used
-            by `np.random`. To ensure the results are reproducible, pass an int
-            to instanciate the seed, or a RandomState instance (recommended).
+            If None (default), the default numpy random generator is used.
+            To ensure that the results are reproducible, pass an integer
+            that will be used as seed for the random number generation, or
+            a Numpy random Generator instance (recommended), or a Numpy
+            RandomState instance (legacy).
 
         dtype : torch.dtype, optional
             Floating point number type/precision used for number storage and
@@ -88,6 +91,10 @@ class Data(object):
 
         ntot : int
             Total number of variables in the dataset (sum of nobs).
+
+        dtype : torch.dtype
+            Floating point number type/precision used for number storage and
+            computations. Default is `torch.float64`.
     """
 
     def __init__(
@@ -102,6 +109,15 @@ class Data(object):
 
         # dtype
         self.dtype = dtype
+
+        # random number generation
+        if random_state is None:
+            random_state = np.random.default_rng()
+        elif isinstance(random_state, int):
+            random_state = np.random.default_rng(random_state)
+        else:
+            assert isinstance(random_state, np.random.Generator) or \
+                isinstance(random_state, np.random.RandomState)
 
         # process data
         try:
@@ -183,8 +199,9 @@ class Data(object):
                     self.nobs[n] = n_landmarks_n
                     self.index[n] = self.index[n][ny_ind]
 
-        except AttributeError:
+        except AttributeError as e:
             print(f'Unknown data type {type(data_n)}')
+            raise e
         self.ntot = sum(self.nobs.values())
 
     def __str__(self):

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -303,7 +303,9 @@ class Statistics(object):
             # output
             return sp, ev
 
-    def compute_centering_matrix(self, landmarks=False, low_mem_footprint=False):
+    def compute_centering_matrix(
+        self, landmarks=False, low_mem_footprint=False
+    ):
         """
         Computes a projection matrix usefull for the kernel trick.
 

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -339,6 +339,10 @@ class Statistics(object):
                 The centering matrix.
 
         """
+        if landmarks and self.data_ny is None:
+            raise ValueError(
+                "Cannot use landmarks, Nystrom approximation not provided."
+            )
         data = self.data if not landmarks else self.data_ny
         if not landmarks or self.anchor_basis == 'w':
             if stacked:
@@ -414,6 +418,10 @@ class Statistics(object):
             K : torch.Tensor,
                 Gram matrix of interest.
         """
+        if landmarks and self.data_ny is None:
+            raise ValueError(
+                "Cannot use landmarks, Nystrom approximation not provided."
+            )
         data = self.data if not landmarks else self.data_ny
         D = cat([x for x in data.data.values()], axis=0)
         K = self.kernel(D, D)

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -443,23 +443,32 @@ class Statistics(object):
         Kw = 1 / self.data_ny.ntot * multi_dot([P, K, P])
         return Statistics.ordered_eigsy(Kw, self.eps, self.clip_eigval)
 
-    def diagonalize_centered_gram(self):
+    def compute_centered_gram(self, low_mem_footprint=False):
         """
-        Diagonalizes the bicentered Gram matrix which shares its spectrum
+        Compute the bicentered Gram matrix which shares its spectrum
         with the within covariance operator in the RKHS.
+
+        Parameters
+        ----------
+            low_mem_footprint : bool, optional
+                True by default. If True, a little trick is used to perform
+                the computations without storing the full n x n matrix
+                centering matrix in the Nystrom case.
+                If False, the default computations requiring the full
+                n x n matrix centering matrix is used in the in Nystrom
+                computation.
+                Without effect when not using Nystrom.
+
 
         Returns
         -------
-            Eigenvalues and eigenvectors, later stored in attributes 'sp' and
-            'ev' respectively.
+            Kw : bicentered Gram matrix.
 
         """
         # Computing centering matrix P:
-        P = self.compute_centering_matrix()
-
-        print("______________ DIAGONALIZATION ________________")
-        print("centering matrix =")
-        print(P)
+        P = self.compute_centering_matrix(
+            stacked=self.data_ny is not None and low_mem_footprint
+        )
 
         # Nytrom version:
         if self.data_ny is not None:
@@ -482,18 +491,74 @@ class Statistics(object):
             # Calculating the centering matrix for the Nystrom approximation:
             Kmn = self.compute_kmn()
             Lp_inv_12 = diag(self.sp_anchors ** (-1/2))
-            Pm = self.compute_centering_matrix(landmarks=True)
+            Pm = self.compute_centering_matrix(landmarks=True, stacked=False)
 
             # Calculating the matrix to diagonalise with Nystrom:
-            Kw = (1 / (self.data.ntot * self.data_ny.ntot)
-                  * multi_dot([Lp_inv_12, self.ev_anchors.T, Pm, Kmn, P,
-                               Kmn.T, Pm, self.ev_anchors, Lp_inv_12]))
+            if low_mem_footprint:
+                # trick to avoid storing a n x n centering
+                sample_size = list(self.data.nobs.values())
 
-            print(f"Kw shape = {Kw.shape}")
+                Kw = (
+                    1 / (self.data.ntot * self.data_ny.ntot) *
+                    multi_dot([
+                        Lp_inv_12, self.ev_anchors.T, Pm,
+                        multi_dot([
+                            Kmn[:, :sample_size[0]],
+                            P[:sample_size[0], :],
+                            Kmn[:, :sample_size[0]].T
+                        ]) +
+                        multi_dot([
+                            Kmn[:, -sample_size[1]:],
+                            P[-sample_size[1]:, :],
+                            Kmn[:, -sample_size[1]:].T
+                        ]),
+                        Pm,
+                        self.ev_anchors,
+                        Lp_inv_12
+                    ])
+                )
+            else:
+                # original version
+                Kw = (
+                    1 / (self.data.ntot * self.data_ny.ntot) *
+                    multi_dot([
+                        Lp_inv_12, self.ev_anchors.T, Pm, Kmn, P,
+                        Kmn.T, Pm, self.ev_anchors, Lp_inv_12
+                    ])
+                )
+
         # Standard version:
         else:
             K = self.compute_gram()
             Kw = 1 / self.data.ntot * multi_dot([P, K, P])
+
+        # output
+        return Kw
+
+    def diagonalize_centered_gram(self, low_mem_footprint=True):
+        """
+        Diagonalizes the bicentered Gram matrix which shares its spectrum
+        with the within covariance operator in the RKHS.
+
+        Parameters
+        ----------
+            low_mem_footprint : bool, optional
+                True by default. If True, a little trick is used to perform
+                the computations without storing the full n x n matrix
+                centering matrix in the Nystrom case.
+                If False, the default computations requiring the full
+                n x n matrix centering matrix is used in the in Nystrom
+                computation.
+                Without effect when not using Nystrom.
+
+        Returns
+        -------
+            Eigenvalues and eigenvectors, later stored in attributes 'sp' and
+            'ev' respectively.
+
+        """
+        # Compute the bicentered Gram matrix
+        Kw = self.compute_centered_gram(low_mem_footprint)
 
         # Diagonalisation with a function in C++:
         return Statistics.ordered_eigsy(Kw, self.eps, self.clip_eigval)

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -303,7 +303,7 @@ class Statistics(object):
             # output
             return sp, ev
 
-    def compute_centering_matrix(self, landmarks=False, stacked=False):
+    def compute_centering_matrix(self, landmarks=False, low_mem_footprint=False):
         """
         Computes a projection matrix usefull for the kernel trick.
 
@@ -317,19 +317,18 @@ class Statistics(object):
         Pn = [I1 - 1/n1 J1 ,    012     ]
              [     021     ,I2 - 1/n2 J2]
 
-        If `stacked=True`, then only return
+        If `low_mem_footprint=True`, then only return
 
-        Pn = [I1 - 1/n1 J1]
-             [I2 - 1/n2 J2]
+        Pn = list([I1 - 1/n1 J1], [I2 - 1/n2 J2])
 
         Parameters
         ----------
             landmarks : bool, optional
                 False by default. If True, performs the computations on the
                 the Nystrom dataset (landmarks).
-            stacked : bool, optional
+            low_mem_footprint : bool, optional
                 False by default. If True, the centering matrix for each
-                sample are returned stacked in an n x m matrix (c.f. details).
+                sample are returned in a list (c.f. details).
                 This mode is specific to be used by
                 `self.diagonalize_centered_gram(low_mem_footprint=True)`.
 
@@ -345,17 +344,15 @@ class Statistics(object):
             )
         data = self.data if not landmarks else self.data_ny
         if not landmarks or self.anchor_basis == 'w':
-            if stacked:
+            if low_mem_footprint:
                 # specific mode not returning a square matrix
                 effectifs = list(data.nobs.values())
 
-                return vstack(
-                    [
-                        eye(nell, dtype=self.dtype) -
-                        1/nell*ones(nell, nell, dtype=self.dtype)
-                        for nell in effectifs
-                    ]
-                )
+                return [
+                    eye(nell, dtype=self.dtype) -
+                    1/nell*ones(nell, nell, dtype=self.dtype)
+                    for nell in effectifs
+                ]
             else:
                 # generic mode
                 In = eye(data.ntot)
@@ -363,9 +360,9 @@ class Statistics(object):
 
                 cumul_effectifs = np.cumsum([0]+effectifs)
 
-                # Computing a bloc diagonal matrix where the ith diagonal bloc is
-                # J_ni, an (ni x ni) matrix full of 1/ni where ni is the size
-                # of the ith group
+                # Computing a bloc diagonal matrix where the ith diagonal bloc
+                # is J_ni, an (ni x ni) matrix full of 1/ni where ni is the
+                # size of the ith group
                 diag_Jn_by_n = cat([
                     cat([
                         zeros(nprec, nell, dtype=self.dtype),
@@ -467,7 +464,7 @@ class Statistics(object):
         """
         # Computing centering matrix P:
         P = self.compute_centering_matrix(
-            stacked=self.data_ny is not None and low_mem_footprint
+            low_mem_footprint=self.data_ny is not None and low_mem_footprint
         )
 
         # Nytrom version:
@@ -491,7 +488,9 @@ class Statistics(object):
             # Calculating the centering matrix for the Nystrom approximation:
             Kmn = self.compute_kmn()
             Lp_inv_12 = diag(self.sp_anchors ** (-1/2))
-            Pm = self.compute_centering_matrix(landmarks=True, stacked=False)
+            Pm = self.compute_centering_matrix(
+                landmarks=True, low_mem_footprint=False
+            )
 
             # Calculating the matrix to diagonalise with Nystrom:
             if low_mem_footprint:
@@ -504,12 +503,12 @@ class Statistics(object):
                         Lp_inv_12, self.ev_anchors.T, Pm,
                         multi_dot([
                             Kmn[:, :sample_size[0]],
-                            P[:sample_size[0], :],
+                            P[0],
                             Kmn[:, :sample_size[0]].T
                         ]) +
                         multi_dot([
                             Kmn[:, -sample_size[1]:],
-                            P[-sample_size[1]:, :],
+                            P[1],
                             Kmn[:, -sample_size[1]:].T
                         ]),
                         Pm,

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from torch import cdist, cat, matmul, exp, mv, dot, diag, sqrt
-from torch import ones, eye, zeros, finfo
+from torch import ones, eye, zeros, finfo, vstack
 from torch.linalg import multi_dot, eigh
 import warnings
 
@@ -303,7 +303,7 @@ class Statistics(object):
             # output
             return sp, ev
 
-    def compute_centering_matrix(self, landmarks=False):
+    def compute_centering_matrix(self, landmarks=False, stacked=False):
         """
         Computes a projection matrix usefull for the kernel trick.
 
@@ -315,13 +315,23 @@ class Statistics(object):
             (or nxanchors x nyanchors and nyanchors x nxanchors if nystrom).
 
         Pn = [I1 - 1/n1 J1 ,    012     ]
-                [     021     ,I2 - 1/n2 J2]
+             [     021     ,I2 - 1/n2 J2]
+
+        If `stacked=True`, then only return
+
+        Pn = [I1 - 1/n1 J1]
+             [I2 - 1/n2 J2]
 
         Parameters
         ----------
             landmarks : bool, optional
                 False by default. If True, performs the computations on the
                 the Nystrom dataset (landmarks).
+            stacked : bool, optional
+                False by default. If True, the centering matrix for each
+                sample are returned stacked in an n x m matrix (c.f. details).
+                This mode is specific to be used by
+                `self.diagonalize_centered_gram(low_mem_footprint=True)`.
 
         Returns
         -------
@@ -331,28 +341,36 @@ class Statistics(object):
         """
         data = self.data if not landmarks else self.data_ny
         if not landmarks or self.anchor_basis == 'w':
-            In = eye(data.ntot)
-            effectifs = list(data.nobs.values())
+            if stacked:
+                # specific mode not returning a square matrix
+                effectifs = list(data.nobs.values())
 
-            cumul_effectifs = np.cumsum([0]+effectifs)
+                return vstack(
+                    [
+                        eye(nell, dtype=self.dtype) -
+                        1/nell*ones(nell, nell, dtype=self.dtype)
+                        for nell in effectifs
+                    ]
+                )
+            else:
+                # generic mode
+                In = eye(data.ntot)
+                effectifs = list(data.nobs.values())
 
-            # Computing a bloc diagonal matrix where the ith diagonal bloc is
-            # J_ni, an (ni x ni) matrix full of 1/ni where ni is the size
-            # of the ith group
-            diag_Jn_by_n = cat([
-                cat([
-                    zeros(nprec, nell, dtype=self.dtype),
-                    1/nell*ones(nell, nell, dtype=self.dtype),
-                    zeros(data.ntot - nprec - nell, nell, dtype=self.dtype)
-                ], dim=0)
-                for nell, nprec in zip(effectifs, cumul_effectifs)
-            ], dim=1)
-            print("______________ DEBUGGING CENTERING MATRIX ________________")
-            print(f"Nystrom? {landmarks}")
-            print(f"data shape {effectifs}")
-            print(f"In matrix shape {In.shape}")
-            print(f"diag_Jn_by_n matrix shape {diag_Jn_by_n.shape}")
-            return In - diag_Jn_by_n
+                cumul_effectifs = np.cumsum([0]+effectifs)
+
+                # Computing a bloc diagonal matrix where the ith diagonal bloc is
+                # J_ni, an (ni x ni) matrix full of 1/ni where ni is the size
+                # of the ith group
+                diag_Jn_by_n = cat([
+                    cat([
+                        zeros(nprec, nell, dtype=self.dtype),
+                        1/nell*ones(nell, nell, dtype=self.dtype),
+                        zeros(data.ntot - nprec - nell, nell, dtype=self.dtype)
+                    ], dim=0)
+                    for nell, nprec in zip(effectifs, cumul_effectifs)
+                ], dim=1)
+                return In - diag_Jn_by_n
         elif self.anchor_basis == 'k':
             return eye(data.ntot, dtype=self.dtype)
         elif self.anchor_basis == 's':

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -48,7 +48,7 @@ def mediane(x, y=None):
             warnings.warn('warning: all your dataset is null')
         return mean
     else:
-        return dtot.median()
+        return median
 
 
 def linear_kernel(x, y):

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -351,7 +351,7 @@ class Statistics(object):
             print(f"Nystrom? {landmarks}")
             print(f"data shape {effectifs}")
             print(f"In matrix shape {In.shape}")
-            print(f"diag_Jn_by_n matrix shape {diag_Jn_by_n.shape})
+            print(f"diag_Jn_by_n matrix shape {diag_Jn_by_n.shape}")
             return In - diag_Jn_by_n
         elif self.anchor_basis == 'k':
             return eye(data.ntot, dtype=self.dtype)

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -576,10 +576,8 @@ class Statistics(object):
             Corresponds to the product PK omega in the kFDA statistic.
 
         """
-        # Calculating the bi-centering vector Omega and
-        # the centering matrix Pbi
+        # Calculating the bi-centering vector Omega
         omega = self.compute_omega()  # vector with 1/n1 and -1/n2
-        Pbi = self.compute_centering_matrix()  # Centering by block matrix
         if self.data_ny is not None:
             Lz12 = diag(self.sp_anchors**(-1/2))
             Kzx = self.compute_kmn()
@@ -587,6 +585,7 @@ class Statistics(object):
             pkm = (1 / np.sqrt(self.data_ny.ntot)
                    * mv(Lz12, mv(self.ev_anchors.T, mv(Pi, mv(Kzx, omega)))))
         else:
+            Pbi = self.compute_centering_matrix()  # Centering by block matrix
             Kx = self.compute_gram()
             pkm = mv(Pbi, mv(Kx, omega))
         return pkm
@@ -728,7 +727,6 @@ class Statistics(object):
             - normalize the vectors with respect to n_anchors as in pkm
             - separate the different nystrom approaches
         """
-        Pbi = self.compute_centering_matrix()
         if self.sp is None and self.ev is None:
             self.sp, self.ev = self.diagonalize_centered_gram()
         if self.data_ny is not None:
@@ -742,6 +740,7 @@ class Statistics(object):
                                                             self.ev_anchors.T,
                                                             Kzx]).T
         else:
+            Pbi = self.compute_centering_matrix()
             Kx = self.compute_gram()
             epk = multi_dot([self.ev.T[:t], Pbi, Kx]).T
         return epk

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -347,6 +347,11 @@ class Statistics(object):
                 ], dim=0)
                 for nell, nprec in zip(effectifs, cumul_effectifs)
             ], dim=1)
+            print("______________ DEBUGGING CENTERING MATRIX ________________")
+            print(f"Nystrom? {landmarks}")
+            print(f"data shape {effectifs}")
+            print(f"In matrix shape {In.shape}")
+            print(f"diag_Jn_by_n matrix shape {diag_Jn_by_n.shape})
             return In - diag_Jn_by_n
         elif self.anchor_basis == 'k':
             return eye(data.ntot, dtype=self.dtype)

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 from torch import cdist, cat, matmul, exp, mv, dot, diag, sqrt
-from torch import ones, eye, zeros, finfo, vstack
+from torch import ones, eye, zeros, finfo
+import torch as t
 from torch.linalg import multi_dot, eigh
 import warnings
 
@@ -303,9 +304,7 @@ class Statistics(object):
             # output
             return sp, ev
 
-    def compute_centering_matrix(
-        self, landmarks=False, low_mem_footprint=False
-    ):
+    def compute_centering_matrix(self, landmarks=False):
         """
         Computes a projection matrix usefull for the kernel trick.
 
@@ -319,20 +318,11 @@ class Statistics(object):
         Pn = [I1 - 1/n1 J1 ,    012     ]
              [     021     ,I2 - 1/n2 J2]
 
-        If `low_mem_footprint=True`, then only return
-
-        Pn = list([I1 - 1/n1 J1], [I2 - 1/n2 J2])
-
         Parameters
         ----------
             landmarks : bool, optional
                 False by default. If True, performs the computations on the
                 the Nystrom dataset (landmarks).
-            low_mem_footprint : bool, optional
-                False by default. If True, the centering matrix for each
-                sample are returned in a list (c.f. details).
-                This mode is specific to be used by
-                `self.diagonalize_centered_gram(low_mem_footprint=True)`.
 
         Returns
         -------
@@ -346,34 +336,24 @@ class Statistics(object):
             )
         data = self.data if not landmarks else self.data_ny
         if not landmarks or self.anchor_basis == 'w':
-            if low_mem_footprint:
-                # specific mode not returning a square matrix
-                effectifs = list(data.nobs.values())
 
-                return [
-                    eye(nell, dtype=self.dtype) -
-                    1/nell*ones(nell, nell, dtype=self.dtype)
-                    for nell in effectifs
-                ]
-            else:
-                # generic mode
-                In = eye(data.ntot)
-                effectifs = list(data.nobs.values())
+            In = eye(data.ntot)
+            effectifs = list(data.nobs.values())
 
-                cumul_effectifs = np.cumsum([0]+effectifs)
+            cumul_effectifs = np.cumsum([0]+effectifs)
 
-                # Computing a bloc diagonal matrix where the ith diagonal bloc
-                # is J_ni, an (ni x ni) matrix full of 1/ni where ni is the
-                # size of the ith group
-                diag_Jn_by_n = cat([
-                    cat([
-                        zeros(nprec, nell, dtype=self.dtype),
-                        1/nell*ones(nell, nell, dtype=self.dtype),
-                        zeros(data.ntot - nprec - nell, nell, dtype=self.dtype)
-                    ], dim=0)
-                    for nell, nprec in zip(effectifs, cumul_effectifs)
-                ], dim=1)
-                return In - diag_Jn_by_n
+            # Computing a bloc diagonal matrix where the ith diagonal bloc
+            # is J_ni, an (ni x ni) matrix full of 1/ni where ni is the
+            # size of the ith group
+            diag_Jn_by_n = cat([
+                cat([
+                    zeros(nprec, nell, dtype=self.dtype),
+                    1/nell*ones(nell, nell, dtype=self.dtype),
+                    zeros(data.ntot - nprec - nell, nell, dtype=self.dtype)
+                ], dim=0)
+                for nell, nprec in zip(effectifs, cumul_effectifs)
+            ], dim=1)
+            return In - diag_Jn_by_n
         elif self.anchor_basis == 'k':
             return eye(data.ntot, dtype=self.dtype)
         elif self.anchor_basis == 's':
@@ -451,23 +431,18 @@ class Statistics(object):
         ----------
             low_mem_footprint : bool, optional
                 True by default. If True, a little trick is used to perform
-                the computations without storing the full n x n matrix
+                the computations without storing the full n x n
                 centering matrix in the Nystrom case.
                 If False, the default computations requiring the full
-                n x n matrix centering matrix is used in the in Nystrom
+                n x n centering matrix is used in the Nystrom
                 computation.
                 Without effect when not using Nystrom.
-
 
         Returns
         -------
             Kw : bicentered Gram matrix.
 
         """
-        # Computing centering matrix P:
-        P = self.compute_centering_matrix(
-            low_mem_footprint=self.data_ny is not None and low_mem_footprint
-        )
 
         # Nytrom version:
         if self.data_ny is not None:
@@ -490,36 +465,41 @@ class Statistics(object):
             # Calculating the centering matrix for the Nystrom approximation:
             Kmn = self.compute_kmn()
             Lp_inv_12 = diag(self.sp_anchors ** (-1/2))
-            Pm = self.compute_centering_matrix(
-                landmarks=True, low_mem_footprint=False
-            )
+            Pm = self.compute_centering_matrix(landmarks=True)
 
             # Calculating the matrix to diagonalise with Nystrom:
-            if low_mem_footprint:
-                # trick to avoid storing a n x n centering
+            if low_mem_footprint and self.anchor_basis == 'w':
+                # trick to avoid storing a n x n centering matrix
                 sample_size = list(self.data.nobs.values())
 
+                # computing centered gram
                 Kw = (
                     1 / (self.data.ntot * self.data_ny.ntot) *
                     multi_dot([
                         Lp_inv_12, self.ev_anchors.T, Pm,
                         multi_dot([
                             Kmn[:, :sample_size[0]],
-                            P[0],
-                            Kmn[:, :sample_size[0]].T
+                            Kmn[:, :sample_size[0]].T - 1/sample_size[0] *
+                            t.sum(Kmn[:, :sample_size[0]], dim=1)
+                            # use pytorch broadcasting
                         ]) +
                         multi_dot([
                             Kmn[:, -sample_size[1]:],
-                            P[1],
-                            Kmn[:, -sample_size[1]:].T
+                            Kmn[:, -sample_size[1]:].T - 1/sample_size[1] *
+                            t.sum(Kmn[:, -sample_size[1]:], dim=1)
+                            # use pytorch broadcasting
                         ]),
                         Pm,
                         self.ev_anchors,
                         Lp_inv_12
                     ])
                 )
+
             else:
                 # original version
+                # computing centering matrix
+                P = self.compute_centering_matrix()
+                # computing centered gram
                 Kw = (
                     1 / (self.data.ntot * self.data_ny.ntot) *
                     multi_dot([
@@ -528,9 +508,13 @@ class Statistics(object):
                     ])
                 )
 
-        # Standard version:
+        # Standard version (no Nystrom):
         else:
+            # centering matrix
+            P = self.compute_centering_matrix()
+            # gram matrix
             K = self.compute_gram()
+            # centered gram
             Kw = 1 / self.data.ntot * multi_dot([P, K, P])
 
         # output

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -431,6 +431,10 @@ class Statistics(object):
         # Computing centering matrix P:
         P = self.compute_centering_matrix()
 
+        print("______________ DIAGONALIZATION ________________")
+        print("centering matrix =")
+        print(P)
+
         # Nytrom version:
         if self.data_ny is not None:
             # Computing Nystrom anchors:

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -462,6 +462,8 @@ class Statistics(object):
             Kw = (1 / (self.data.ntot * self.data_ny.ntot)
                   * multi_dot([Lp_inv_12, self.ev_anchors.T, Pm, Kmn, P,
                                Kmn.T, Pm, self.ev_anchors, Lp_inv_12]))
+
+            print(f"Kw shape = {Kw.shape}")
         # Standard version:
         else:
             K = self.compute_gram()

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -153,12 +153,15 @@ class Ktest(Statistics):
             'kfda_proj' contains the cumulated sum of the values in
             'kfda_proj_contrib'.
 
-        rnd_gen :  int, RandomState instance or None
+        rnd_gen : int, numpy.random.Generator instance,
+                numpy.random.RandomState instance or None
             Determines random number generation for the Nystrom approximation
-            and for the permutations. If None (default), the generator is
-            the RandomState instance used by `np.random`. To ensure the results
-            are reproducible, pass an int to instanciate the seed, or a
-            RandomState instance (recommended).
+            and for the permutations. If None (default), the default numpy
+            random generator is used.
+            To ensure that the results are reproducible, pass an integer
+            that will be used as seed for the random number generation, or
+            a Numpy random Generator instance (recommended), or a Numpy
+            RandomState instance (legacy).
     """
 
     def __init__(
@@ -180,12 +183,15 @@ class Ktest(Statistics):
         self.eps = eps
         self.clip_eigval = clip_eigval
 
-        if isinstance(random_state, np.random.RandomState):
-            self.rnd_gen = random_state
+        # random number generation
+        if random_state is None:
+            self.rnd_gen = np.random.default_rng()
         elif isinstance(random_state, int):
-            self.rnd_gen = np.random.RandomState(random_state)
+            self.rnd_gen = np.random.default_rng(random_state)
         else:
-            self.rnd_gen = np.random
+            assert isinstance(random_state, np.random.Generator) or \
+                isinstance(random_state, np.random.RandomState)
+            self.rnd_gen = random_state
 
         ### Kernel:
         self.kernel_function = kernel_function

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -1,0 +1,165 @@
+import numpy as np
+import pandas as pd
+import pytest
+import torch as t
+
+from ktest.data import Data
+
+
+@pytest.fixture
+def data_shape():
+    """Number of rows and columns in dummy data for tests."""
+    yield (1000, 100)
+
+
+@pytest.fixture
+def dummy_data(data_shape):
+    """Generate dummy data for testing (two groups, no difference)"""
+    # generate random data (under H0, no separation)
+    rng = np.random.default_rng(42)
+    data_array = rng.normal(loc=0, scale=1, size=data_shape)
+
+    # create a data frame from random gaussian data
+    data = pd.DataFrame(
+        data=data_array,
+        columns=[f"col{i+1}" for i in range(data_shape[1])]
+    )
+
+    # create meta data frame indicating two groups
+    meta = pd.Series(
+        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data, meta
+
+
+@pytest.fixture
+def ktest_data(dummy_data):
+    """Convert pandas array to ktest `Data` type."""
+    data = Data(
+        data=dummy_data[0],
+        metadata=dummy_data[1],
+        sample_names=None,
+        dtype=t.float64
+    )
+
+    yield data
+
+
+@pytest.fixture
+def ktest_data_nystrom(dummy_data):
+    """
+    Convert pandas array to ktest `Data` type using Nystrom approximation.
+    """
+    ny_data = Data(
+        data=dummy_data[0],
+        metadata=dummy_data[1],
+        sample_names=None,
+        nystrom=True,
+        n_landmarks=None,
+        landmark_method='random',
+        random_state=None,
+        dtype=t.float64
+    )
+
+    yield ny_data
+
+
+class TestData:
+    """Implement unit tests for Data class."""
+
+    def test_init(self, ktest_data, dummy_data, data_shape):
+        """Testing Data object instantiation."""
+
+        # check subsample names
+        assert list(ktest_data.sample_names) == ['c1', 'c2']
+
+        # check total number of observations
+        assert ktest_data.ntot == data_shape[0]
+
+        # check number of variables
+        assert ktest_data.nvar == data_shape[1]
+
+        # check data type
+        assert ktest_data.dtype == t.float64
+
+        # check data attribute
+        assert isinstance(ktest_data.data, dict)
+
+        # check variable index
+        assert all(ktest_data.variables == dummy_data[0].columns)
+
+        # check details about data, index and nobs attributes
+        for subsample in ktest_data.sample_names:
+            # expected number of observations in subsample
+            exp_nobs = np.sum(dummy_data[1] == subsample)
+
+            # check number of observations in subsample
+            assert ktest_data.nobs[subsample] == exp_nobs
+
+            # check subsample index
+            assert all(
+                ktest_data.index[subsample] ==
+                dummy_data[0][dummy_data[1] == subsample].index
+            )
+
+            # check subsample data
+            assert isinstance(ktest_data.data[subsample], t.Tensor)
+            assert list(ktest_data.data[subsample].shape) == \
+                [exp_nobs, data_shape[1]]
+            np.testing.assert_equal(
+                ktest_data.data[subsample].numpy(),
+                dummy_data[0][dummy_data[1] == subsample].to_numpy()
+            )
+
+    def test_init_nystrom(self, ktest_data_nystrom, dummy_data, data_shape):
+        """Testing Data object instantiation when using Nystrom."""
+
+        # assert True
+
+        # check subsample names
+        assert list(ktest_data_nystrom.sample_names) == ['c1', 'c2']
+
+        # expected Nystrom sampling dimension
+        exp_nobs_ny = data_shape[0] // 5
+
+        # check total number of observations
+        assert ktest_data_nystrom.ntot == exp_nobs_ny
+
+        # check number of variables
+        assert ktest_data_nystrom.nvar == data_shape[1]
+
+        # check data type
+        assert ktest_data_nystrom.dtype == t.float64
+
+        # check data attribute
+        assert isinstance(ktest_data_nystrom.data, dict)
+
+        # check variable index
+        assert all(ktest_data_nystrom.variables == dummy_data[0].columns)
+
+        # check details about data, index and nobs attributes
+        for subsample in ktest_data_nystrom.sample_names:
+            # expected number of observations in subsample
+            exp_nobs = exp_nobs_ny // 2
+
+            # check number of observations in subsample
+            assert ktest_data_nystrom.nobs[subsample] == exp_nobs
+
+            # check subsample index
+            assert all(
+                ktest_data_nystrom.index[subsample] ==
+                dummy_data[0].iloc[ktest_data_nystrom.index[subsample]].index
+            )
+
+            # check subsample data
+            assert isinstance(ktest_data_nystrom.data[subsample], t.Tensor)
+            assert list(ktest_data_nystrom.data[subsample].shape) == \
+                [exp_nobs, data_shape[1]]
+            np.testing.assert_equal(
+                ktest_data_nystrom.data[subsample].numpy(),
+                dummy_data[0].iloc[
+                    ktest_data_nystrom.index[subsample]
+                ].to_numpy()
+            )

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -10,6 +10,7 @@ from ktest.data import Data
 def data_shape():
     """Number of rows and columns in dummy data for tests."""
     yield (1000, 100)
+    # yield (50, 20)
 
 
 @pytest.fixture

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -263,7 +263,7 @@ class TestStatistics:
         """Testing centering matrix computation."""
 
         # compute expected centering matrix
-        def _exp_cent_mat(data: Data, low_mem_footprint: bool = False):
+        def _exp_cent_mat(data: Data):
             """
             Compute expected centering matrix for a given data object.
             """
@@ -280,67 +280,62 @@ class TestStatistics:
 
                 mat_block_list.append(subsample_block)
 
-            if not low_mem_footprint:
-                return block_diag(*mat_block_list)
-            else:
-                return mat_block_list
+            return block_diag(*mat_block_list)
 
-        # no Nystrom, standard block diagonal centering matrix
-        res = kstat.compute_centering_matrix(
-            landmarks=False, low_mem_footprint=False
-        )
+        # no Nystrom
+        res = kstat.compute_centering_matrix(landmarks=False)
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat.data, low_mem_footprint=False)
+        exp_dim = kstat.data.ntot
+        assert list(res.shape) == [exp_dim, exp_dim]
+
+        exp_res = _exp_cent_mat(kstat.data)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
-        # no Nystrom, block centering matrix in a list
-        res = kstat.compute_centering_matrix(
-            landmarks=False, low_mem_footprint=True
-        )
-        for mat in res:
-            assert isinstance(mat, t.Tensor)
-            assert len(mat.shape) == 2
-
-        exp_res = _exp_cent_mat(kstat.data, low_mem_footprint=True)
-
-        for mat, exp_mat in zip(res, exp_res):
-            np.testing.assert_allclose(
-                mat.numpy(), exp_mat, rtol=0, atol=1e-11
-            )
-
-        # Nystrom (but not available), standard block diagonal centering matrix
+        # Nystrom (but not available)
         txt = "Cannot use landmarks, Nystrom approximation not provided."
         with pytest.raises(ValueError, match=txt):
-            res = kstat.compute_centering_matrix(landmarks=True, low_mem_footprint=False)
+            res = kstat.compute_centering_matrix(landmarks=True)
 
-        # Nystrom, standard block diagonal centering matrix
-        res = kstat_nystrom.compute_centering_matrix(
-            landmarks=True, low_mem_footprint=False
-        )
+        # Nystrom: anchor_basis == 'w' (default mode)
+        res = kstat_nystrom.compute_centering_matrix(landmarks=True)
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, low_mem_footprint=False)
+        exp_dim = kstat_nystrom.data_ny.ntot
+        assert list(res.shape) == [exp_dim, exp_dim]
+
+        exp_res = _exp_cent_mat(kstat_nystrom.data_ny)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
-        # Nystrom, block centering matrix in a list
-        res = kstat_nystrom.compute_centering_matrix(
-            landmarks=True, low_mem_footprint=True
-        )
-        for mat in res:
-            assert isinstance(mat, t.Tensor)
-            assert len(mat.shape) == 2
+        # Nystrom: anchor_basis == 'k'
+        kstat_nystrom.anchor_basis = 'k'
+        res = kstat_nystrom.compute_centering_matrix(landmarks=True)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, low_mem_footprint=True)
+        exp_dim = kstat_nystrom.data_ny.ntot
+        assert list(res.shape) == [exp_dim, exp_dim]
 
-        for mat, exp_mat in zip(res, exp_res):
-            np.testing.assert_allclose(
-                mat.numpy(), exp_mat, rtol=0, atol=1e-11
-            )
+        exp_res = np.eye(exp_dim)
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+
+        # Nystrom: anchor_basis == 's'
+        kstat_nystrom.anchor_basis = 's'
+        res = kstat_nystrom.compute_centering_matrix(landmarks=True)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
+
+        exp_dim = kstat_nystrom.data_ny.ntot
+        assert list(res.shape) == [exp_dim, exp_dim]
+
+        exp_res = np.eye(exp_dim) - 1/exp_dim * np.ones((exp_dim, exp_dim))
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
     def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """
@@ -357,7 +352,35 @@ class TestStatistics:
 
         t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
 
-        # Nystrom
+        # Nystrom: anchor_basis == 'w' (default mode)
+        res1 = kstat_nystrom.compute_centered_gram(low_mem_footprint=False)
+        res2 = kstat_nystrom.compute_centered_gram(low_mem_footprint=True)
+
+        exp_dim = kstat_nystrom.sp_anchors.shape[0]
+
+        assert isinstance(res1, t.Tensor)
+        assert list(res1.shape) == [exp_dim, exp_dim]
+        assert isinstance(res2, t.Tensor)
+        assert list(res2.shape) == [exp_dim, exp_dim]
+
+        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+
+        # Nystrom: anchor_basis == 'k'
+        kstat_nystrom.anchor_basis = 'k'
+        res1 = kstat_nystrom.compute_centered_gram(low_mem_footprint=False)
+        res2 = kstat_nystrom.compute_centered_gram(low_mem_footprint=True)
+
+        exp_dim = kstat_nystrom.sp_anchors.shape[0]
+
+        assert isinstance(res1, t.Tensor)
+        assert list(res1.shape) == [exp_dim, exp_dim]
+        assert isinstance(res2, t.Tensor)
+        assert list(res2.shape) == [exp_dim, exp_dim]
+
+        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+
+        # Nystrom: anchor_basis == 's'
+        kstat_nystrom.anchor_basis = 's'
         res1 = kstat_nystrom.compute_centered_gram(low_mem_footprint=False)
         res2 = kstat_nystrom.compute_centered_gram(low_mem_footprint=True)
 

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch as t
 import types
+from scipy.linalg import block_diag
 
 from ktest.kernel_statistics import Statistics
 from ktest.data import Data
@@ -137,3 +138,66 @@ class TestStatistics:
         assert kstat.ev is None
         assert kstat.sp_anchors is None
         assert kstat.ev_anchors is None
+
+    def test_compute_centering_matrix(self, kstat):
+        """Testing centering matrix computation."""
+        assert True
+
+        # compute expected centering matrix
+        def _exp_cent_mat(data: Data, stacked: bool = False):
+            """
+            Compute expected centering matrix for a given data object.
+            """
+
+            mat_block_list = []
+
+            for subdata in data.data.values():
+
+                nobs_subsample = subdata.shape[0]
+
+                subsample_block = np.eye(nobs_subsample) - \
+                    1/nobs_subsample * \
+                        np.ones((nobs_subsample, nobs_subsample))
+
+                mat_block_list.append(subsample_block)
+
+            if not stacked:
+                return block_diag(*mat_block_list)
+            else:
+                return np.vstack(mat_block_list)
+
+        # no Nystrom, standard block diagonal centering matrix
+        res = kstat.compute_centering_matrix(landmarks=False, stacked=False)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
+
+        exp_res = _exp_cent_mat(kstat.data, stacked=False)
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+
+        # no Nystrom, stacked block centering matrix
+        res = kstat.compute_centering_matrix(landmarks=False, stacked=True)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
+
+        exp_res = _exp_cent_mat(kstat.data, stacked=True)
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+
+        # Nystrom, standard block diagonal centering matrix
+        res = kstat.compute_centering_matrix(landmarks=True, stacked=False)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
+
+        exp_res = _exp_cent_mat(kstat.data_ny, stacked=False)
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+
+        # Nystrom, stacked block centering matrix
+        res = kstat.compute_centering_matrix(landmarks=True, stacked=True)
+        assert isinstance(res, t.Tensor)
+        assert len(res.shape) == 2
+
+        exp_res = _exp_cent_mat(kstat.data_ny, stacked=True)
+
+        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -10,6 +10,83 @@ from ktest.data import Data
 from .test_data import data_shape, dummy_data, ktest_data, ktest_data_nystrom
 
 
+def assert_eigenvectors(
+    a: np.ndarray | t.Tensor, b: np.ndarray | t.Tensor,
+    rtol: float = 0, atol: float = 1e-11
+):
+    """
+    Assert that two set of ordered eigen vectors (by increasing or decreasing
+    eigen value order) are identical up to a rotation of angle pi, i.e.
+    assert that for any column index j, we have `a[:, j] == b[:, j]` or
+    `a[:, j] == -b[:, j]`, meaning that scalar product
+    <a[:, j], b[:, j]> = 1 or -1.
+    """
+
+    # check type
+    assert isinstance(a, np.ndarray) and isinstance(b, np.ndarray) or \
+        isinstance(a, t.Tensor) and isinstance(b, t.Tensor)
+
+    # check dimension
+    assert a.shape == b.shape
+
+    # setup required functions
+    einsum_fun = np.einsum if isinstance(a, np.ndarray) else t.einsum
+
+    abs_fun = np.abs if isinstance(a, np.ndarray) else t.abs
+
+    def assert_eigendecomp(x):
+        """Check that a vector is equal to a vector of 1 in absolute value."""
+        return \
+            np.testing.assert_allclose(
+                x, np.ones(x.shape, dtype=x.dtype), atol=atol, rtol=rtol
+            ) if isinstance(a, np.ndarray) else \
+            t.testing.assert_close(
+                x, t.ones(x.shape, dtype=x.dtype), atol=atol, rtol=rtol
+            )
+
+    # compute column-wise scalar product
+    col_scal_prod = einsum_fun('ij,ij->j', a, b)
+
+    # check results (assert that all scalar product result are 1 or -1)
+    assert_eigendecomp(abs_fun(col_scal_prod))
+
+
+def test_assert_eigenvectors(dummy_data):
+    """Test function to compare eigen vectors."""
+
+    # get data
+    data_tensor = t.from_numpy(dummy_data[0].values)
+
+    # compute a symmetric matrix to decompose
+    sym_matrix = t.matmul(data_tensor, data_tensor.T)
+
+    # compute eigen decomposition with torch
+    sp1, ev1 = t.linalg.eigh(sym_matrix)
+
+    # compute eigen decomposition with numpy
+    sp2, ev2 = np.linalg.eigh(sym_matrix.numpy())
+
+    # check eigen values
+    np.testing.assert_allclose(
+        sp1.numpy(), sp2, rtol=0, atol=1e-11
+    )
+
+    # torch input
+    assert_eigenvectors(
+        ev1[:, sp1 >= 1e-12],
+        t.from_numpy(ev2[:, sp2 >= 1e-12]),
+        rtol=0, atol=1e-11
+    )
+
+    # numpy input
+    assert_eigenvectors(
+        ev1[:, sp1 >= 1e-12].numpy(),
+        ev2[:, sp2 >= 1e-12],
+        rtol=0, atol=1e-11
+    )
+
+
+
 @pytest.fixture
 def kstat(ktest_data):
     """Define a kernel statistics object without Nystrom approximation."""
@@ -78,7 +155,7 @@ class TestStatistics:
         )
 
         # check eigen vectors for non null eigen values
-        np.testing.assert_allclose(
+        assert_eigenvectors(
             ev.numpy()[:, sp >= 1e-12],
             exp_ev[:, exp_sp >= 1e-12],
             rtol=0, atol=1e-12
@@ -101,7 +178,7 @@ class TestStatistics:
         )
 
         # check eigen vectors for non null eigen values
-        np.testing.assert_allclose(
+        assert_eigenvectors(
             ev.numpy()[:, sp >= 1e-12],
             exp_ev[:, exp_sp >= 1e-12],
             rtol=0, atol=1e-12
@@ -124,7 +201,7 @@ class TestStatistics:
         )
 
         # check eigen vectors for non null eigen values
-        np.testing.assert_allclose(
+        assert_eigenvectors(
             ev.numpy(),
             exp_ev[:, :sp.shape[0]],
             rtol=0, atol=1e-12

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -1,0 +1,164 @@
+import numpy as np
+import pandas as pd
+import pytest
+import torch as t
+
+from ktest.kernel_statistics import Statistics
+from ktest.data import Data
+
+
+@pytest.fixture(scope="module")
+def data_shape():
+    """Number of rows and columns in dummy data for tests."""
+    yield (1000, 100)
+
+
+@pytest.fixture(scope="module")
+def dummy_data(data_shape):
+    """Generate dummy data for testing (two groups, no difference)"""
+    # generate random data (under H0, no separation)
+    rng = np.random.default_rng(42)
+    data_array = rng.normal(loc=0, scale=1, size=data_shape)
+
+    # create a data frame from random gaussian data
+    data = pd.DataFrame(
+        data=data_array,
+        columns=[f"col{i+1}" for i in range(data_shape[1])]
+    )
+
+    # create meta data frame indicating two groups
+    meta = pd.Series(
+        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data, meta
+
+
+@pytest.fixture(scope="module")
+def ktest_data(dummy_data):
+    """Convert pandas array to ktest `Data` type."""
+    # Original data
+    data = Data(
+        data=dummy_data[0], metadata=dummy_data[1],
+        sample_names=None,
+        dtype=t.float64
+    )
+    # Nytrom data
+    ny_data = Data(
+        data=dummy_data[0],
+        metadata=dummy_data[1],
+        sample_names=None,
+        nystrom=True,
+        n_landmarks=None,
+        landmark_method='random',
+        random_state=None,
+        dtype=t.float64
+    )
+    # outout
+    yield data, ny_data
+
+
+@pytest.fixture
+def kstat(ktest_data):
+    """Define a kernel statistics object."""
+    # kernel stat object
+    kstat = Statistics(
+        data=ktest_data[0],
+        kernel_function='gauss',
+        bandwidth='median',
+        median_coef=1,
+        data_nystrom=ktest_data[1],
+        n_anchors=None,
+        anchor_basis='w',
+        eps=None, clip_eigval=True
+    )
+    # output
+    yield kstat
+
+
+class TestStatistics:
+    """Implement test for Statistics class methods."""
+
+    def test_ordered_eigsy(self, dummy_data):
+        """Test eigen decomposition"""
+        # get data
+        data_tensor = t.from_numpy(dummy_data[0].values)
+
+        # compute a symmetric matrix to decompose
+        sym_matrix = t.matmul(data_tensor, data_tensor.T)
+
+        # compute eigen decomposition (without clipping)
+        sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=None, clip=False)
+
+        # check output
+        assert isinstance(sp, t.Tensor)
+        assert list(sp.shape) == [sym_matrix.shape[0]]
+        assert isinstance(ev, t.Tensor)
+        assert list(ev.shape) == [sym_matrix.shape[0], sym_matrix.shape[0]]
+
+        # compute eigen decomposition with numpy to compare
+        # /!\ eigen values/vectors are in reverse order
+        exp_sp, exp_ev = np.linalg.eigh(sym_matrix.numpy())
+
+        # revert order
+        exp_sp = np.flip(exp_sp)
+        exp_ev = np.flip(exp_ev, axis=1)
+
+        # check eigen values
+        np.testing.assert_allclose(
+            sp.numpy(), exp_sp, rtol=0, atol=1e-11
+        )
+
+        # check eigen vectors for non null eigen values
+        np.testing.assert_allclose(
+            ev.numpy()[:, sp >= 1e-12],
+            exp_ev[:, exp_sp >= 1e-12],
+            rtol=0, atol=1e-12
+        )
+
+        # compute eigen decomposition
+        # with clipping, no specified threshold
+        with pytest.warns(UserWarning):
+            sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=None, clip=True)
+
+        # check output
+        assert isinstance(sp, t.Tensor)
+        assert list(sp.shape) < [sym_matrix.shape[0]]
+        assert isinstance(ev, t.Tensor)
+        assert list(ev.shape) == [sym_matrix.shape[0], sp.shape[0]]
+
+        # check eigen values
+        np.testing.assert_allclose(
+            sp.numpy(), exp_sp[:sp.shape[0]], rtol=0, atol=1e-11
+        )
+
+        # check eigen vectors for non null eigen values
+        np.testing.assert_allclose(
+            ev.numpy()[:, sp >= 1e-12],
+            exp_ev[:, exp_sp >= 1e-12],
+            rtol=0, atol=1e-12
+        )
+
+        # compute eigen decomposition
+        # with clipping, specified threshold
+        with pytest.warns(UserWarning):
+            sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=1e-12, clip=True)
+
+        # check output
+        assert isinstance(sp, t.Tensor)
+        assert list(sp.shape) < [sym_matrix.shape[0]]
+        assert isinstance(ev, t.Tensor)
+        assert list(ev.shape) == [sym_matrix.shape[0], sp.shape[0]]
+
+        # check eigen values
+        np.testing.assert_allclose(
+            sp.numpy(), exp_sp[:sp.shape[0]], rtol=0, atol=1e-11
+        )
+
+        # check eigen vectors for non null eigen values
+        np.testing.assert_allclose(
+            ev.numpy(),
+            exp_ev[:, :sp.shape[0]],
+            rtol=0, atol=1e-12
+        )

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -329,3 +329,114 @@ class TestStatistics:
         exp_res = _exp_cent_mat(kstat_nystrom.data_ny, stacked=True)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+
+    def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
+        """
+        Testing centered Gram matrix computation,
+        with or without the computing trick to avoid storing the full
+        n x n centering matrix."""
+
+        # no Nystrom: no effect of 'low_mem_footprint' option
+        res1 = kstat.compute_centered_gram(low_mem_footprint=False)
+        res2 = kstat.compute_centered_gram(low_mem_footprint=True)
+
+        assert isinstance(res1, t.Tensor)
+        assert list(res1.shape) == [data_shape[0], data_shape[0]]
+
+        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+
+        # Nystrom
+        res1 = kstat_nystrom.compute_centered_gram(low_mem_footprint=False)
+        res2 = kstat_nystrom.compute_centered_gram(low_mem_footprint=True)
+
+        exp_dim = kstat_nystrom.sp_anchors.shape[0]
+
+        assert isinstance(res1, t.Tensor)
+        assert list(res1.shape) == [exp_dim, exp_dim]
+        assert isinstance(res2, t.Tensor)
+        assert list(res2.shape) == [exp_dim, exp_dim]
+
+        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+
+    def test_diagonalize_centered_gram(self, kstat, kstat_nystrom, data_shape):
+        """
+        Testing centered Gram matrix diagonalization,
+        with or without the computing trick to avoid storing the full
+        n x n centering matrix."""
+
+        # no Nystrom: no effect of 'low_mem_footprint' option
+        sp1, ev1 = kstat.diagonalize_centered_gram(low_mem_footprint=False)
+        sp2, ev2 = kstat.diagonalize_centered_gram(low_mem_footprint=True)
+
+        # check output
+        assert isinstance(sp1, t.Tensor)
+        assert list(sp1.shape) == [data_shape[0] - 2]
+        assert isinstance(ev1, t.Tensor)
+        assert list(ev1.shape) == [data_shape[0], data_shape[0] - 2]
+        # note: last 2 eigen values are clipped
+
+        t.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
+        t.testing.assert_close(ev1, ev2, rtol=0, atol=1e-12)
+
+        # compute eigen decomposition with numpy to compare
+        # /!\ eigen values/vectors are in reverse order
+        Kw = kstat.compute_centered_gram(low_mem_footprint=True)
+        exp_sp, exp_ev = np.linalg.eigh(Kw.numpy())
+
+        # revert order
+        exp_sp = np.flip(exp_sp)
+        exp_ev = np.flip(exp_ev, axis=1)
+
+        # check eigen values
+        np.testing.assert_allclose(
+            sp1.numpy()[sp1 >= 1e-12], exp_sp[exp_sp >= 1e-12],
+            rtol=0, atol=1e-11
+        )
+
+        # check eigen vectors for non null eigen values
+        assert_eigenvectors(
+            ev1.numpy()[:, sp1 >= 1e-12],
+            exp_ev[:, exp_sp >= 1e-12],
+            rtol=0, atol=1e-12
+        )
+
+        # Nystrom
+        sp1, ev1 = kstat_nystrom.diagonalize_centered_gram(
+            low_mem_footprint=False
+        )
+        sp2, ev2 = kstat_nystrom.diagonalize_centered_gram(
+            low_mem_footprint=True
+        )
+
+        # check output
+        assert isinstance(sp1, t.Tensor)
+        assert list(sp1.shape) == [data_shape[0] // 5 - 2]
+        assert isinstance(ev1, t.Tensor)
+        assert list(ev1.shape) == \
+            [data_shape[0] // 5 - 2, data_shape[0] // 5 - 2]
+        # note: last 2 eigen values are clipped
+
+        t.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
+        assert_eigenvectors(ev1, ev2, rtol=0, atol=1e-12)
+
+        # compute eigen decomposition with numpy to compare
+        # /!\ eigen values/vectors are in reverse order
+        Kw = kstat_nystrom.compute_centered_gram(low_mem_footprint=True)
+        exp_sp, exp_ev = np.linalg.eigh(Kw.numpy())
+
+        # revert order
+        exp_sp = np.flip(exp_sp)
+        exp_ev = np.flip(exp_ev, axis=1)
+
+        # check eigen values
+        np.testing.assert_allclose(
+            sp1.numpy()[sp1 >= 1e-12], exp_sp[exp_sp >= 1e-12],
+            rtol=0, atol=1e-11
+        )
+
+        # check eigen vectors for non null eigen values
+        assert_eigenvectors(
+            ev1.numpy()[:, sp1 >= 1e-12],
+            exp_ev[:, exp_sp >= 1e-12],
+            rtol=0, atol=1e-12
+        )

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -263,7 +263,7 @@ class TestStatistics:
         """Testing centering matrix computation."""
 
         # compute expected centering matrix
-        def _exp_cent_mat(data: Data, stacked: bool = False):
+        def _exp_cent_mat(data: Data, low_mem_footprint: bool = False):
             """
             Compute expected centering matrix for a given data object.
             """
@@ -280,55 +280,67 @@ class TestStatistics:
 
                 mat_block_list.append(subsample_block)
 
-            if not stacked:
+            if not low_mem_footprint:
                 return block_diag(*mat_block_list)
             else:
-                return np.vstack(mat_block_list)
+                return mat_block_list
 
         # no Nystrom, standard block diagonal centering matrix
-        res = kstat.compute_centering_matrix(landmarks=False, stacked=False)
+        res = kstat.compute_centering_matrix(
+            landmarks=False, low_mem_footprint=False
+        )
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat.data, stacked=False)
+        exp_res = _exp_cent_mat(kstat.data, low_mem_footprint=False)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
-        # no Nystrom, stacked block centering matrix
-        res = kstat.compute_centering_matrix(landmarks=False, stacked=True)
-        assert isinstance(res, t.Tensor)
-        assert len(res.shape) == 2
+        # no Nystrom, block centering matrix in a list
+        res = kstat.compute_centering_matrix(
+            landmarks=False, low_mem_footprint=True
+        )
+        for mat in res:
+            assert isinstance(mat, t.Tensor)
+            assert len(mat.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat.data, stacked=True)
+        exp_res = _exp_cent_mat(kstat.data, low_mem_footprint=True)
 
-        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+        for mat, exp_mat in zip(res, exp_res):
+            np.testing.assert_allclose(
+                mat.numpy(), exp_mat, rtol=0, atol=1e-11
+            )
 
         # Nystrom (but not available), standard block diagonal centering matrix
         txt = "Cannot use landmarks, Nystrom approximation not provided."
         with pytest.raises(ValueError, match=txt):
-            res = kstat.compute_centering_matrix(landmarks=True, stacked=False)
+            res = kstat.compute_centering_matrix(landmarks=True, low_mem_footprint=False)
 
         # Nystrom, standard block diagonal centering matrix
         res = kstat_nystrom.compute_centering_matrix(
-            landmarks=True, stacked=False
+            landmarks=True, low_mem_footprint=False
         )
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, stacked=False)
+        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, low_mem_footprint=False)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
-        # Nystrom, stacked block centering matrix
+        # Nystrom, block centering matrix in a list
         res = kstat_nystrom.compute_centering_matrix(
-            landmarks=True, stacked=True
+            landmarks=True, low_mem_footprint=True
         )
-        assert isinstance(res, t.Tensor)
-        assert len(res.shape) == 2
+        for mat in res:
+            assert isinstance(mat, t.Tensor)
+            assert len(mat.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, stacked=True)
+        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, low_mem_footprint=True)
 
-        np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
+        for mat, exp_mat in zip(res, exp_res):
+            np.testing.assert_allclose(
+                mat.numpy(), exp_mat, rtol=0, atol=1e-11
+            )
 
     def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import torch as t
+import types
 
 from ktest.kernel_statistics import Statistics
 from ktest.data import Data
@@ -27,7 +28,7 @@ def kstat(ktest_data, ktest_data_nystrom):
 
 
 class TestStatistics:
-    """Implement test for Statistics class methods."""
+    """Implement unit tests for Statistics class."""
 
     def test_ordered_eigsy(self, dummy_data):
         """Test eigen decomposition"""
@@ -111,3 +112,28 @@ class TestStatistics:
             exp_ev[:, :sp.shape[0]],
             rtol=0, atol=1e-12
         )
+
+    def test_init(self, kstat, data_shape):
+        """Testing Statictics object instantiation."""
+
+        assert isinstance(kstat.data, Data)
+        assert isinstance(kstat.data_ny, Data)
+        assert kstat.dtype == t.float64
+        assert kstat.eps is None or isinstance(kstat.eps, float)
+        assert isinstance(kstat.clip_eigval, bool) and kstat.clip_eigval
+        assert isinstance(kstat.n_anchors, int) and \
+            kstat.n_anchors == data_shape[0] // 5
+        assert isinstance(kstat.anchor_basis, str) and \
+            kstat.anchor_basis == 'w'
+        assert isinstance(kstat.kernel_function, str) and \
+            kstat.kernel_function == 'gauss'
+        assert isinstance(kstat.bandwidth, str) and kstat.bandwidth == 'median'
+        assert isinstance(kstat.median_coef, int) and kstat.median_coef == 1
+        assert isinstance(kstat.kernel, types.FunctionType)
+        assert isinstance(kstat.computed_bandwidth, t.Tensor) and \
+            len(kstat.computed_bandwidth.shape) == 0 and \
+            kstat.computed_bandwidth.dtype == t.float64
+        assert kstat.sp is None
+        assert kstat.ev is None
+        assert kstat.sp_anchors is None
+        assert kstat.ev_anchors is None

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -182,7 +182,7 @@ class TestStatistics:
         assert kstat_nystrom.sp_anchors is None
         assert kstat_nystrom.ev_anchors is None
 
-    def test_compute_centering_matrix(self, kstat):
+    def test_compute_centering_matrix(self, kstat, kstat_nystrom):
         """Testing centering matrix computation."""
 
         # compute expected centering matrix
@@ -226,20 +226,29 @@ class TestStatistics:
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
+        # Nystrom (but not available), standard block diagonal centering matrix
+        txt = "Cannot use landmarks, Nystrom approximation not provided."
+        with pytest.raises(ValueError, match=txt):
+            res = kstat.compute_centering_matrix(landmarks=True, stacked=False)
+
         # Nystrom, standard block diagonal centering matrix
-        res = kstat.compute_centering_matrix(landmarks=True, stacked=False)
+        res = kstat_nystrom.compute_centering_matrix(
+            landmarks=True, stacked=False
+        )
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat.data_ny, stacked=False)
+        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, stacked=False)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
         # Nystrom, stacked block centering matrix
-        res = kstat.compute_centering_matrix(landmarks=True, stacked=True)
+        res = kstat_nystrom.compute_centering_matrix(
+            landmarks=True, stacked=True
+        )
         assert isinstance(res, t.Tensor)
         assert len(res.shape) == 2
 
-        exp_res = _exp_cent_mat(kstat.data_ny, stacked=True)
+        exp_res = _exp_cent_mat(kstat_nystrom.data_ny, stacked=True)
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -11,8 +11,24 @@ from .test_data import data_shape, dummy_data, ktest_data, ktest_data_nystrom
 
 
 @pytest.fixture
-def kstat(ktest_data, ktest_data_nystrom):
-    """Define a kernel statistics object."""
+def kstat(ktest_data):
+    """Define a kernel statistics object without Nystrom approximation."""
+    # kernel stat object
+    kstat = Statistics(
+        data=ktest_data,
+        kernel_function='gauss',
+        bandwidth='median',
+        median_coef=1,
+        data_nystrom=None,
+        eps=None, clip_eigval=True
+    )
+    # output
+    yield kstat
+
+
+@pytest.fixture
+def kstat_nystrom(ktest_data, ktest_data_nystrom):
+    """Define a kernel statistics object using Nystrom approximation."""
     # kernel stat object
     kstat = Statistics(
         data=ktest_data,
@@ -114,16 +130,16 @@ class TestStatistics:
             rtol=0, atol=1e-12
         )
 
-    def test_init(self, kstat, data_shape):
+    def test_init(self, kstat, kstat_nystrom, data_shape):
         """Testing Statictics object instantiation."""
 
+        # no Nystrom
         assert isinstance(kstat.data, Data)
-        assert isinstance(kstat.data_ny, Data)
+        assert kstat.data_ny is None
         assert kstat.dtype == t.float64
         assert kstat.eps is None or isinstance(kstat.eps, float)
         assert isinstance(kstat.clip_eigval, bool) and kstat.clip_eigval
-        assert isinstance(kstat.n_anchors, int) and \
-            kstat.n_anchors == data_shape[0] // 5
+        assert kstat.n_anchors is None
         assert isinstance(kstat.anchor_basis, str) and \
             kstat.anchor_basis == 'w'
         assert isinstance(kstat.kernel_function, str) and \
@@ -139,9 +155,35 @@ class TestStatistics:
         assert kstat.sp_anchors is None
         assert kstat.ev_anchors is None
 
+        # Nystrom
+        assert isinstance(kstat_nystrom.data, Data)
+        assert isinstance(kstat_nystrom.data_ny, Data)
+        assert kstat_nystrom.dtype == t.float64
+        assert kstat_nystrom.eps is None or \
+            isinstance(kstat_nystrom.eps, float)
+        assert isinstance(kstat_nystrom.clip_eigval, bool) and \
+            kstat_nystrom.clip_eigval
+        assert isinstance(kstat_nystrom.n_anchors, int) and \
+            kstat_nystrom.n_anchors == data_shape[0] // 5
+        assert isinstance(kstat_nystrom.anchor_basis, str) and \
+            kstat_nystrom.anchor_basis == 'w'
+        assert isinstance(kstat_nystrom.kernel_function, str) and \
+            kstat_nystrom.kernel_function == 'gauss'
+        assert isinstance(kstat_nystrom.bandwidth, str) and \
+            kstat_nystrom.bandwidth == 'median'
+        assert isinstance(kstat_nystrom.median_coef, int) and \
+            kstat_nystrom.median_coef == 1
+        assert isinstance(kstat_nystrom.kernel, types.FunctionType)
+        assert isinstance(kstat_nystrom.computed_bandwidth, t.Tensor) and \
+            len(kstat_nystrom.computed_bandwidth.shape) == 0 and \
+            kstat_nystrom.computed_bandwidth.dtype == t.float64
+        assert kstat_nystrom.sp is None
+        assert kstat_nystrom.ev is None
+        assert kstat_nystrom.sp_anchors is None
+        assert kstat_nystrom.ev_anchors is None
+
     def test_compute_centering_matrix(self, kstat):
         """Testing centering matrix computation."""
-        assert True
 
         # compute expected centering matrix
         def _exp_cent_mat(data: Data, stacked: bool = False):

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -1,74 +1,23 @@
 import numpy as np
-import pandas as pd
 import pytest
 import torch as t
 
 from ktest.kernel_statistics import Statistics
 from ktest.data import Data
 
-
-@pytest.fixture(scope="module")
-def data_shape():
-    """Number of rows and columns in dummy data for tests."""
-    yield (1000, 100)
-
-
-@pytest.fixture(scope="module")
-def dummy_data(data_shape):
-    """Generate dummy data for testing (two groups, no difference)"""
-    # generate random data (under H0, no separation)
-    rng = np.random.default_rng(42)
-    data_array = rng.normal(loc=0, scale=1, size=data_shape)
-
-    # create a data frame from random gaussian data
-    data = pd.DataFrame(
-        data=data_array,
-        columns=[f"col{i+1}" for i in range(data_shape[1])]
-    )
-
-    # create meta data frame indicating two groups
-    meta = pd.Series(
-        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
-    )
-
-    # output
-    yield data, meta
-
-
-@pytest.fixture(scope="module")
-def ktest_data(dummy_data):
-    """Convert pandas array to ktest `Data` type."""
-    # Original data
-    data = Data(
-        data=dummy_data[0], metadata=dummy_data[1],
-        sample_names=None,
-        dtype=t.float64
-    )
-    # Nytrom data
-    ny_data = Data(
-        data=dummy_data[0],
-        metadata=dummy_data[1],
-        sample_names=None,
-        nystrom=True,
-        n_landmarks=None,
-        landmark_method='random',
-        random_state=None,
-        dtype=t.float64
-    )
-    # outout
-    yield data, ny_data
+from .test_data import data_shape, dummy_data, ktest_data, ktest_data_nystrom
 
 
 @pytest.fixture
-def kstat(ktest_data):
+def kstat(ktest_data, ktest_data_nystrom):
     """Define a kernel statistics object."""
     # kernel stat object
     kstat = Statistics(
-        data=ktest_data[0],
+        data=ktest_data,
         kernel_function='gauss',
         bandwidth='median',
         median_coef=1,
-        data_nystrom=ktest_data[1],
+        data_nystrom=ktest_data_nystrom,
         n_anchors=None,
         anchor_basis='w',
         eps=None, clip_eigval=True

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -114,11 +114,16 @@ def test_ktest_precision(dummy_ktest, assert_equal_ktest):
         # use warning in that case because max absolute difference is
         # often higher than required threshold (but not always)
         warnings.warn(e)
-    npt.assert_allclose(
-        kt_f32.kfda_pval_asymp.to_numpy()[:max_len],
-        kt_f64.kfda_pval_asymp.to_numpy()[:max_len],
-        rtol=0, atol=1e-5
-    )
+    try:
+        npt.assert_allclose(
+            kt_f32.kfda_pval_asymp.to_numpy()[:max_len],
+            kt_f64.kfda_pval_asymp.to_numpy()[:max_len],
+            rtol=0, atol=1e-5
+        )
+    except AssertionError as e:
+        # use warning in that case because max absolute difference is
+        # often higher than required threshold (but not always)
+        warnings.warn(e)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Use a computing trick when computing centered Gram matrix to avoid storing the full n x n centering matrix
- Implement several unit tests
- Several minor modifications

Details:

* ba11322 Modify computation to totally avoid using a centering matrix when computing centered Gram in "low memory footprint" mode + revert centering matrix computation to original version (because not used in this mode)
* 735add3 fix indentation
* 9d46590 bump package version
* d7b865b add ipython as requirement for dev
* 4a0c7d8 add try/except statement to avoid assert error when larger discrepancy between float32 and float64 (which happens sometime)
* 6db1c39 fix random number generation (following new numpy guidelines)
* c88e684 allow to test different data configuration (by commenting/uncommenting)
* 2d5fb1b move the centering matrix computing to avoid computing it when unused (in Nystrom case)
* 5eb8a52 fix low memory footprint centering matrix computing in case the observation classes are not balanced (and the centering matrices per group cannot be stacked) by storing the centering matrices per group in a list + rename option to enable/disable the computing trick in the corresponding function
* 8389245 split function to diagonalize centered gram into one function to compute centered gram (using or not trick to avoid storing n x n centering matrix) and one function to do the diagonalization + implement corresponding unit testing (including comparing results with or without this computing trick
* 3f20789 implement function to verify that two set of eigen vectors correspond to the same eigen decomposition (i.e. that corresponding vectors are equal of opposite)
* 0f76489 raise an error when trying to use landmarks when Nystrom approximation is not used
* 13885ac tests for the different cases with or without Nystrom approximation when computing the centering matrix
* f946198 define different Statistics object (with or without Nystrom approximation) for use in tests
* 44e04d2 FEATURE: add on option to only return non null diagonal blocks in the centering matrix (to avoid storing an n x n matrix even when using Nystrom) + implement corresponding unit tests
* e537b9f tests Statistics object init
* 356878d use fixture defining dummy data to run tests from test_data module (instead) of redifining them
* 217a643 consider tests as a submodule to be able to import fixture from one file to another
* 1f8e652 implement unit tests for Data class
* 0a41704 Fix random number generation + fix doc + raise Exception in case of issue with initialization
* 196d3d9 WIP: implement unit tests for kernel statistics object (eigen decomposition testing is done)
* 8b90776 avoid recomputing the median that is already computed
* 72da5a4 add verbosity for debugging regarding Gram matrix in Nystrom case
* f8991a1 add verbosity for debugging (centering matrix)
* 675d69a fix typo in verbosity added for debugging
* 8038d16 add debugging verbosity when computing centering matrix to run some tests