### PR TITLE
Fix nystrom subsampling

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.1.1"
+version = "1.1.2"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/src/ktest/data.py
+++ b/python/src/ktest/data.py
@@ -63,6 +63,20 @@ class Data(object):
             Floating point number type/precision used for number storage and
             computations. Default is `torch.float64`.
 
+        safe_subsample : bool
+            Implement safe subsampling for Nystrom approximation, i.e. check
+            that not all variables are constant in subsampled data. If not,
+            subsampling is redone for at most `n_subsample_trial` times.
+            Default is `True`.
+
+        n_subsample_trial : integer, optional
+            Number of times to retry subsampling in case all columns
+            have constant values after subsampling. Default is `100`.
+
+        verbose : int | bool, optional
+            Verbosity level, see `ktest.utils.verbosity()` for more details.
+            Default is `0` and no verbosity output.
+
     Attributes
     ----------
         sample_names : 1-dimensional array-like
@@ -95,12 +109,18 @@ class Data(object):
         dtype : torch.dtype
             Floating point number type/precision used for number storage and
             computations. Default is `torch.float64`.
+
+        verbose : int | bool, optional
+            Verbosity level, see `ktest.utils.verbosity()` for more details.
+            Default is `0` and no verbosity output.
+
     """
 
     def __init__(
         self, data, metadata, sample_names=None, nystrom=False,
         n_landmarks=None, landmark_method='kmeans++', random_state=None,
-        dtype=t.float64
+        dtype=t.float64, safe_subsample=True, n_subsample_trial=100,
+        verbose=0
     ):
         # init
         self.data = {}
@@ -110,16 +130,38 @@ class Data(object):
         # dtype
         self.dtype = dtype
 
-        # random number generation
-        if random_state is None:
-            random_state = np.random.default_rng()
-        elif isinstance(random_state, int):
-            random_state = np.random.default_rng(random_state)
-        else:
-            assert isinstance(random_state, np.random.Generator) or \
-                isinstance(random_state, np.random.RandomState)
+        # Nystrom subsampling setup
+        self.verbose = verbose
 
         # process data
+        self._process_data(
+            data, metadata, sample_names, nystrom,
+            n_landmarks, landmark_method, random_state,
+            safe_subsample, n_subsample_trial
+        )
+
+
+    def __str__(self):
+        s = f"\n{self.nvar} features across {self.ntot} observations"
+        s += "\nComparison: "
+        s += f"{self.sample_names[0]} "
+        s += f"({self.nobs[self.sample_names[0]]} observations)"
+        s += f" and {self.sample_names[1]} "
+        s += f"({self.nobs[self.sample_names[1]]} observations)."
+        return s
+
+    def _process_data(
+        self, data, metadata, sample_names, nystrom,
+        n_landmarks, landmark_method, random_state,
+        safe_subsample, n_subsample_trial
+    ):
+        """
+        Process input data when initializing object.
+
+        Note: internal function, see `ktest.data.Data` documentation for
+        input argument description.
+        """
+
         try:
             assert len(data.squeeze().shape) <= 2, \
                 'Data has to be at most 2-dimensional'
@@ -177,38 +219,93 @@ class Data(object):
                         data_n.copy()
                     self.data[n] = t.from_numpy(X).type(self.dtype)
 
-                if nystrom:
-                    n_ = meta_fmt.isin(self.sample_names).sum()
-                    n_landmarks_n = (min(n_landmarks * self.nobs[n] // n_,
-                                         self.nobs[n])
-                                     if n_landmarks is not None
-                                     else self.nobs[n] // 5)
-                    if landmark_method == 'random':
-                        ny_ind = random_state.choice(self.nobs[n],
-                                                     size=n_landmarks_n,
-                                                     replace=False)
-                    if landmark_method == 'kmeans++':
-                        rnd_st = random_state \
-                            if isinstance(
-                                random_state, (np.random.RandomState, int)
-                            ) else None
-                        _, ny_ind = kmeans_plusplus(self.data[n].numpy(),
-                                                    n_clusters=n_landmarks_n,
-                                                    random_state=rnd_st)
-                    self.data[n] = self.data[n][ny_ind]
-                    self.nobs[n] = n_landmarks_n
-                    self.index[n] = self.index[n][ny_ind]
-
         except AttributeError as e:
             print(f'Unknown data type {type(data_n)}')
             raise e
+
+        # total retained observations in selected subsamples
         self.ntot = sum(self.nobs.values())
 
-    def __str__(self):
-        s = f"\n{self.nvar} features across {self.ntot} observations"
-        s += "\nComparison: "
-        s += f"{self.sample_names[0]} "
-        s += f"({self.nobs[self.sample_names[0]]} observations)"
-        s += f" and {self.sample_names[1]} "
-        s += f"({self.nobs[self.sample_names[1]]} observations)."
-        return s
+        # Nystrom
+        if nystrom:
+            self._subsample(
+                n_landmarks, landmark_method, random_state, safe_subsample,
+                n_subsample_trial
+            )
+
+    def _subsample(
+        self, n_landmarks, landmark_method, random_state, safe_subsample,
+        n_subsample_trial
+    ):
+        """
+        Subsampling data for Nystrom approximation.
+
+        Note: internal function, see `ktest.data.Data` documentation for
+        input argument description.
+        """
+        # random number generation
+        if random_state is None:
+            random_state = np.random.default_rng()
+        elif isinstance(random_state, int):
+            random_state = np.random.default_rng(random_state)
+        else:
+            assert isinstance(random_state, np.random.Generator) or \
+                isinstance(random_state, np.random.RandomState)
+            random_state = random_state
+
+        # iterate through samples
+        for n, data_n in self.data.items():
+
+            # number for landmarks in sample
+            n_landmarks_n = (
+                min(
+                    n_landmarks * self.nobs[n] // self.ntot,
+                    self.nobs[n]
+                ) if n_landmarks is not None else self.nobs[n] // 5
+            )
+
+            # check variance in subsample to avoid any constant column
+            # and re-do subsampling if needed
+            for counter in range(n_subsample_trial):
+
+                if landmark_method == 'random':
+                    ny_ind = random_state.choice(
+                        self.nobs[n],
+                        size=n_landmarks_n,
+                        replace=False
+                    )
+                elif landmark_method == 'kmeans++':
+                    rnd_st = random_state \
+                        if isinstance(
+                            random_state, (np.random.RandomState, int)
+                        ) else None
+                    _, ny_ind = kmeans_plusplus(
+                        self.data[n].numpy(),
+                        n_clusters=n_landmarks_n,
+                        random_state=rnd_st
+                    )
+                else:
+                    raise ValueError("unsupported 'landmark_method'")
+
+                # variance check (if required)
+                if (
+                    not safe_subsample or
+                    t.any(t.var(self.data[n][ny_ind], dim=0) > 0)
+                ):
+                    break
+                elif counter == n_subsample_trial - 1:
+                    msg = " ".join([
+                        "Subsampling failed after",
+                        f"{n_subsample_trial} trials.",
+                        "All variables have constant values",
+                        "in at leat one subsample."
+                    ])
+                    raise RuntimeError(msg)
+
+            # save subsamping
+            self.data[n] = self.data[n][ny_ind]
+            self.nobs[n] = n_landmarks_n
+            self.index[n] = self.index[n][ny_ind]
+
+        # update total retained observations in selected subsamples
+        self.ntot = sum(self.nobs.values())

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -743,17 +743,19 @@ class Statistics(object):
         where C is a normalization constant.
 
         Parameters
-            the mean embedding.
-            If True (default), the projections are centered with respect to
-        center : bool, optional
+        ----------
+
+        stat : Pandas.Series
 
         t : int, optional
             Maximal truncation, the default is 100.
 
             kFDA statistics (same as the attribute `kfda_statistic` of class
             Ktest). Required for normalization.
-        stat : Pandas.Series
-        ----------
+
+        center : bool, optional
+            If True (default), the projections are centered with respect to
+            the mean embedding.
 
         Returns
         -------

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -302,8 +302,6 @@ class Ktest(Statistics):
 
         """
         kstatistics = kstat if kstat is not None else self.kstat
-        if verbose <= 0:
-            warnings.simplefilter("ignore")
         if stat == 'kfda':
             test_res = kstatistics.compute_kfda()
         elif stat == 'mmd':
@@ -351,13 +349,11 @@ class Ktest(Statistics):
         if stat == 'kfda' and not permutation:
             if verbose > 0:
                 print('- Computing asymptotic p-values')
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                pval = chi2.sf(self.kfda_statistic, self.kfda_statistic.index)
-                return pd.Series(
-                    pval, index=self.kfda_statistic.index,
-                    dtype=str(self.dtype).replace('torch.', '')
-                )
+            pval = chi2.sf(self.kfda_statistic, self.kfda_statistic.index)
+            return pd.Series(
+                pval, index=self.kfda_statistic.index,
+                dtype=str(self.dtype).replace('torch.', '')
+            )
         else:
             if verbose > 0:
                 print('- Performing permutations to compute p-values:')
@@ -383,6 +379,7 @@ class Ktest(Statistics):
                         landmark_method=self.landmark_method,
                         random_state=self.rnd_gen
                     )
+
                 kstat_perm = Statistics(
                     data_perm,
                     kernel_function=self.kernel_function,
@@ -393,11 +390,11 @@ class Ktest(Statistics):
                     anchor_basis=self.anchor_basis,
                     eps=self.eps, clip_eigval=self.clip_eigval
                 )
-                if verbose >= 3:
-                    warnings.simplefilter("always")
+
                 perm_stats_res = self.compute_test_statistic(
                     stat=stat, kstat=kstat_perm, verbose=verbose-1
                 )
+
                 if stat == 'kfda':
                     stats_count += perm_stats_res[0].ge(self.kfda_statistic)
                 elif stat == 'mmd':
@@ -430,36 +427,40 @@ class Ktest(Statistics):
             - 3: warnings are printed every time they appear.
 
         """
-        if stat == 'kfda':
-            if verbose > 0:
-                print('- Computing kFDA statistic')
-            self.kfda_statistic, self.kfda_statistic_contrib = \
-                self.compute_test_statistic(verbose=verbose)
-            if not permutation:
-                self.kfda_pval_asymp = self.compute_pvalue(verbose=verbose)
-            else:
-                self.kfda_pval_perm = self.compute_pvalue(
-                    permutation=permutation, n_permutations=n_permutations,
-                    verbose=verbose
+        with warnings.catch_warnings():
+            if verbose < 2:
+                warnings.simplefilter("ignore")
+            elif verbose >= 3:
+                warnings.simplefilter("always")
+
+            if stat == 'kfda':
+                if verbose > 0:
+                    print('- Computing kFDA statistic')
+                self.kfda_statistic, self.kfda_statistic_contrib = \
+                    self.compute_test_statistic(verbose=verbose)
+                if not permutation:
+                    self.kfda_pval_asymp = self.compute_pvalue(verbose=verbose)
+                else:
+                    self.kfda_pval_perm = self.compute_pvalue(
+                        permutation=permutation, n_permutations=n_permutations,
+                        verbose=verbose
+                    )
+            elif stat == 'mmd':
+                if verbose > 0:
+                    print('- Computing MMD statistic')
+                self.mmd_statistic = self.compute_test_statistic(
+                    stat=stat, verbose=verbose
                 )
-        elif stat == 'mmd':
-            if verbose > 0:
-                print('- Computing MMD statistic')
-            self.mmd_statistic = self.compute_test_statistic(
-                stat=stat, verbose=verbose
-            )
-            self.mmd_pval_perm = self.compute_pvalue(
-                stat=stat, verbose=verbose, n_permutations=n_permutations
-            )
-        else:
-            if verbose > 0:
-                print(
+                self.mmd_pval_perm = self.compute_pvalue(
+                    stat=stat, verbose=verbose, n_permutations=n_permutations
+                )
+            else:
+                raise ValueError(
                     f"Statistic '{stat}' not recognized. " +
                     "Possible values : 'kfda','mmd'"
-
                 )
 
-    def project(self, t=100, center=True):
+    def project(self, t=100, center=True, verbose=1):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -477,12 +478,18 @@ class Ktest(Statistics):
             the mean embedding.
 
         """
-        if self.kfda_statistic is None:
-            self.test(stat='kfda')
-        (self.kfda_proj,
-         self.kfda_proj_contrib) = self.kstat.compute_projections(
-             self.kfda_statistic, t=t, center=center
-        )
+        with warnings.catch_warnings():
+            if verbose < 2:
+                warnings.simplefilter("ignore")
+            elif verbose >= 3:
+                warnings.simplefilter("always")
+
+            if self.kfda_statistic is None:
+                self.test(stat='kfda')
+            (self.kfda_proj, self.kfda_proj_contrib) = \
+                self.kstat.compute_projections(
+                    self.kfda_statistic, t=t, center=center
+                )
 
     def plot_density(
         self, t=None, t_max=100, colors=None, labels=None, alpha=.5,

--- a/python/src/ktest/utils.py
+++ b/python/src/ktest/utils.py
@@ -1,0 +1,35 @@
+from numbers import Number
+import warnings
+
+
+def verbosity(msg: str, msg_type: str = "print", verbose: int | bool = 0):
+    """
+    Verbosity output function.
+
+    Input:
+        msg (str): message to print.
+        msg_type (str): type of message among `"print"`, `"warning"`.
+        verbose (int | bool): verbosity level, `0` means no output,
+            `1` means only print, `>=2` means print and warning.
+            Note: `verbose=False` is equivalent to `verbose=0` and
+            `verbose=True` is equivalent to `verbose=1`
+
+    Output: no output
+    """
+
+    # check input
+    assert isinstance(msg, str), "`msg` input should be a character string"
+    assert isinstance(msg_type, str) and msg_type in ["print", "warning"], \
+        "`msg_type` input should be either \"print\" or \"warning\""
+    assert isinstance(verbose, bool) or \
+        isinstance(verbose, Number) and verbose.is_integer(), \
+        "`verbosity` input should be a boolean or an integer value"
+
+    # manage verbosity
+    if verbose == 1 and msg_type == "print":
+        print(msg)
+    elif verbose > 1:
+        if msg_type == "print":
+            print(msg)
+        elif msg_type == "warning":
+            warnings.warn(msg, UserWarning)

--- a/python/src/ktest/utils.py
+++ b/python/src/ktest/utils.py
@@ -10,7 +10,7 @@ def verbosity(msg: str, msg_type: str = "print", verbose: int | bool = 0):
         msg (str): message to print.
         msg_type (str): type of message among `"print"`, `"warning"`.
         verbose (int | bool): verbosity level, `0` means no output,
-            `1` means only print, `>=2` means print and warning.
+            `1` means print only, `>=2` means print and warning.
             Note: `verbose=False` is equivalent to `verbose=0` and
             `verbose=True` is equivalent to `verbose=1`
 

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -36,6 +36,31 @@ def dummy_data(data_shape):
 
 
 @pytest.fixture
+def dummy_zidata(data_shape):
+    """
+    Generate dummy zero-inflated data for testing (two groups, no difference).
+    """
+    # generate random data (under H0, no separation)
+    rng = np.random.default_rng(42)
+    data_array = rng.normal(loc=0, scale=1, size=data_shape) * \
+        rng.binomial(n=1, p=0.001, size=data_shape)
+
+    # create a data frame from random gaussian data
+    data = pd.DataFrame(
+        data=data_array,
+        columns=[f"col{i+1}" for i in range(data_shape[1])]
+    )
+
+    # create meta data frame indicating two groups
+    meta = pd.Series(
+        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data, meta
+
+
+@pytest.fixture
 def ktest_data(dummy_data):
     """Convert pandas array to ktest `Data` type."""
     data = Data(
@@ -67,100 +92,220 @@ def ktest_data_nystrom(dummy_data):
     yield ny_data
 
 
+def _check_ktest_data_object(
+        data_obj, data_tab, metadata_tab, data_tab_shape, nystrom=False
+    ):
+    """
+    Function to check a ktest data object with or without Nystrom
+    approximation.
+    """
+
+    # check verbose level
+    assert isinstance(data_obj.verbose, bool) or \
+        isinstance(data_obj.verbose, int) and data_obj.verbose >= 0
+
+    # check subsample names
+    assert list(data_obj.sample_names) == ['c1', 'c2']
+
+    # expected number of total number of observation
+    exp_tot_nobs = data_tab_shape[0] if not nystrom else data_tab_shape[0] // 5
+
+    # check total number of observations
+    assert data_obj.ntot == exp_tot_nobs
+
+    # check number of variables
+    assert data_obj.nvar == data_tab_shape[1]
+
+    # check data type
+    assert data_obj.dtype == t.float64
+
+    # check data attribute
+    assert isinstance(data_obj.data, dict)
+
+    # check variable index
+    assert all(data_obj.variables == data_tab.columns)
+
+    # check details about data, index and nobs attributes
+    for subsample in data_obj.sample_names:
+        # expected number of observations in subsample
+        exp_nobs = np.sum(metadata_tab == subsample) if not nystrom else exp_tot_nobs // 2
+
+        # check number of observations in subsample
+        assert data_obj.nobs[subsample] == exp_nobs
+
+        # check subsample index
+        assert all(
+            data_obj.index[subsample] ==
+            data_tab.iloc[data_obj.index[subsample]].index
+        )
+
+        # check subsample data
+        assert isinstance(data_obj.data[subsample], t.Tensor)
+        assert list(data_obj.data[subsample].shape) == \
+            [exp_nobs, data_tab_shape[1]]
+        np.testing.assert_equal(
+            data_obj.data[subsample].numpy(),
+            data_tab.iloc[
+                data_obj.index[subsample]
+            ].to_numpy()
+        )
+
+
 class TestData:
     """Implement unit tests for Data class."""
 
     def test_init(self, ktest_data, dummy_data, data_shape):
         """Testing Data object instantiation."""
-
-        # check subsample names
-        assert list(ktest_data.sample_names) == ['c1', 'c2']
-
-        # check total number of observations
-        assert ktest_data.ntot == data_shape[0]
-
-        # check number of variables
-        assert ktest_data.nvar == data_shape[1]
-
-        # check data type
-        assert ktest_data.dtype == t.float64
-
-        # check data attribute
-        assert isinstance(ktest_data.data, dict)
-
-        # check variable index
-        assert all(ktest_data.variables == dummy_data[0].columns)
-
-        # check details about data, index and nobs attributes
-        for subsample in ktest_data.sample_names:
-            # expected number of observations in subsample
-            exp_nobs = np.sum(dummy_data[1] == subsample)
-
-            # check number of observations in subsample
-            assert ktest_data.nobs[subsample] == exp_nobs
-
-            # check subsample index
-            assert all(
-                ktest_data.index[subsample] ==
-                dummy_data[0][dummy_data[1] == subsample].index
-            )
-
-            # check subsample data
-            assert isinstance(ktest_data.data[subsample], t.Tensor)
-            assert list(ktest_data.data[subsample].shape) == \
-                [exp_nobs, data_shape[1]]
-            np.testing.assert_equal(
-                ktest_data.data[subsample].numpy(),
-                dummy_data[0][dummy_data[1] == subsample].to_numpy()
-            )
+        _check_ktest_data_object(
+            ktest_data, dummy_data[0], dummy_data[1], data_shape, nystrom=False
+        )
 
     def test_init_nystrom(self, ktest_data_nystrom, dummy_data, data_shape):
         """Testing Data object instantiation when using Nystrom."""
+        _check_ktest_data_object(
+            ktest_data_nystrom, dummy_data[0], dummy_data[1], data_shape,
+            nystrom=True
+        )
 
-        # assert True
+    def test_init_zidata(self, dummy_zidata, data_shape):
+        """
+        Testing Data object instantiation in case of zero-inflated data.
+        """
 
-        # check subsample names
-        assert list(ktest_data_nystrom.sample_names) == ['c1', 'c2']
+        # collect input data
+        data, metadata = dummy_zidata
 
-        # expected Nystrom sampling dimension
-        exp_nobs_ny = data_shape[0] // 5
+        # init data object without nystrom
+        base_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            dtype=t.float64
+        )
 
-        # check total number of observations
-        assert ktest_data_nystrom.ntot == exp_nobs_ny
+        _check_ktest_data_object(
+            base_data, dummy_zidata[0], dummy_zidata[1], data_shape,
+            nystrom=False
+        )
 
-        # check number of variables
-        assert ktest_data_nystrom.nvar == data_shape[1]
+        # init data object with nystrom
+        ny_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            nystrom=True,
+            n_landmarks=None,
+            landmark_method='random',
+            random_state=None,
+            dtype=t.float64
+        )
 
-        # check data type
-        assert ktest_data_nystrom.dtype == t.float64
+        _check_ktest_data_object(
+            ny_data, dummy_zidata[0], dummy_zidata[1], data_shape, nystrom=True
+        )
 
-        # check data attribute
-        assert isinstance(ktest_data_nystrom.data, dict)
+    def test_init_constant_var(self, dummy_data, data_shape):
+        """
+        Testing Data object instantiation in case of one or
+        multiple constant columns in data.
+        """
 
-        # check variable index
-        assert all(ktest_data_nystrom.variables == dummy_data[0].columns)
+        # collect input data
+        data, metadata = dummy_data
 
-        # check details about data, index and nobs attributes
-        for subsample in ktest_data_nystrom.sample_names:
-            # expected number of observations in subsample
-            exp_nobs = exp_nobs_ny // 2
+        # insert one constant column in data
+        data[data.columns[0]].values[:] = 0
 
-            # check number of observations in subsample
-            assert ktest_data_nystrom.nobs[subsample] == exp_nobs
+        # init data object without nystrom
+        base_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            dtype=t.float64
+        )
 
-            # check subsample index
-            assert all(
-                ktest_data_nystrom.index[subsample] ==
-                dummy_data[0].iloc[ktest_data_nystrom.index[subsample]].index
+        _check_ktest_data_object(
+            base_data, data, metadata, data_shape, nystrom=False
+        )
+
+        # init data object with nystrom
+        ny_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            nystrom=True,
+            n_landmarks=None,
+            landmark_method='random',
+            random_state=None,
+            dtype=t.float64
+        )
+
+        _check_ktest_data_object(
+            ny_data, data, metadata, data_shape, nystrom=True
+        )
+
+        # insert constant columns in data (except final one)
+        for col in data.columns[:99]:
+            data[col].values[:] = 0
+
+        # init data object without nystrom
+        base_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            dtype=t.float64
+        )
+
+        _check_ktest_data_object(
+            base_data, data, metadata, data_shape, nystrom=False
+        )
+
+        # init data object with nystrom
+        ny_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            nystrom=True,
+            n_landmarks=None,
+            landmark_method='random',
+            random_state=None,
+            dtype=t.float64
+        )
+
+        _check_ktest_data_object(
+            ny_data, data, metadata, data_shape, nystrom=True
+        )
+
+        # insert constant columns in data (all)
+        for col in data.columns[:99]:
+            data[col].values[:] = 0
+
+        data[data.columns[99]].values[::2] = 0
+
+        # init data object without nystrom
+        base_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            dtype=t.float64
+        )
+
+        _check_ktest_data_object(
+            base_data, data, metadata, data_shape, nystrom=False
+        )
+
+        # init data object with nystrom
+        err_msg = "Subsampling failed after 100 trials. " + \
+            "All variables have constant values in at leat one subsample."
+        with pytest.raises(RuntimeError) as excinfo:
+            ny_data = Data(
+                data=data,
+                metadata=metadata,
+                sample_names=None,
+                nystrom=True,
+                n_landmarks=None,
+                landmark_method='random',
+                random_state=None,
+                dtype=t.float64
             )
-
-            # check subsample data
-            assert isinstance(ktest_data_nystrom.data[subsample], t.Tensor)
-            assert list(ktest_data_nystrom.data[subsample].shape) == \
-                [exp_nobs, data_shape[1]]
-            np.testing.assert_equal(
-                ktest_data_nystrom.data[subsample].numpy(),
-                dummy_data[0].iloc[
-                    ktest_data_nystrom.index[subsample]
-                ].to_numpy()
-            )
+        assert str(excinfo.value) == err_msg

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -277,9 +277,6 @@ class TestData:
         )
 
         # insert constant columns in data (all)
-        for col in data.columns[:99]:
-            data[col].values[:] = 0
-
         data[data.columns[99]].values[::2] = 0
 
         # init data object without nystrom

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -259,6 +259,50 @@ class TestStatistics:
         assert kstat_nystrom.sp_anchors is None
         assert kstat_nystrom.ev_anchors is None
 
+    def test_init_nystrom_constant_var(self, dummy_data, data_shape):
+        """Testing the case of data with a constant column."""
+
+        # collect input data
+        data, metadata = dummy_data
+
+        # insert constant column in data
+        data[data.columns[0]].values[:] = 0
+
+        # init data object with nystrom
+        ny_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            nystrom=True,
+            n_landmarks=None,
+            landmark_method='random',
+            random_state=None,
+            dtype=t.float64
+        )
+
+        # init data object without nystrom
+        base_data = Data(
+            data=data,
+            metadata=metadata,
+            sample_names=None,
+            dtype=t.float64
+        )
+
+        # kernel stat object
+        kstat = Statistics(
+            data=base_data,
+            kernel_function='gauss',
+            bandwidth='median',
+            median_coef=1,
+            data_nystrom=ny_data,
+            n_anchors=None,
+            anchor_basis='w',
+            eps=None, clip_eigval=True
+        )
+
+        # try to compute kfda
+        kstat.compute_kfda()
+
     def test_compute_centering_matrix(self, kstat, kstat_nystrom):
         """Testing centering matrix computation."""
 

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -9,36 +9,10 @@ import warnings
 
 from ktest.tester import Ktest
 
-
-@pytest.fixture(scope="module")
-def data_shape():
-    """Number of rows and columns in dummy data for tests."""
-    yield (1000, 100)
+from .test_data import data_shape, dummy_data, dummy_zidata
 
 
-@pytest.fixture(scope="module")
-def dummy_data(data_shape):
-    """Generate dummy data for testing (two groups, no difference)"""
-    # generate random data (under H0, no separation)
-    rng = np.random.default_rng()
-    data_array = rng.normal(loc=0, scale=1, size=data_shape)
-
-    # create a data frame from random gaussian data
-    data = pd.DataFrame(
-        data=data_array,
-        columns=[f"col{i+1}" for i in range(data_shape[1])]
-    )
-
-    # create meta data frame indicating two groups
-    meta = pd.Series(
-        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
-    )
-
-    # output
-    yield data, meta
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture
 def dummy_ktest(dummy_data):
     """
     Function to create Ktest object from dummy data for testing using a given
@@ -51,7 +25,7 @@ def dummy_ktest(dummy_data):
             dtype=dtype
         )
         # run kfda test
-        kt.test()
+        kt.test(verbose=0)
         # output
         return kt
     # fixture output
@@ -162,7 +136,7 @@ def test_save_load(dummy_ktest, output_file, assert_equal_ktest):
     assert_equal_ktest(kt, kt_2, atol=1e-9)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def exp_data():
     """Data and metadata from experimental transcriptomic dataset."""
     # data frame
@@ -176,7 +150,7 @@ def exp_data():
     yield data, meta, sample_names
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def kt_data(exp_data):
     """Create Ktest object from dummy data for testing."""
     # init object
@@ -184,7 +158,7 @@ def kt_data(exp_data):
         data=exp_data[0], metadata=exp_data[1], sample_names=exp_data[2]
     )
     # run kfda test
-    kt.test()
+    kt.test(verbose=0)
     # output
     yield kt
 
@@ -203,3 +177,56 @@ def test_num_stability(kt_data, assert_equal_ktest):
         assert_equal_ktest(
             kt_data, kt_data_prev, trunc=len(kt_data.kfda_statistic), atol=1e-8
         )
+
+
+@pytest.mark.parametrize("nystrom", [False, True])
+def test_constant_var(dummy_data, data_shape, nystrom):
+    """Testing the case of data with a constant column."""
+
+    # collect input data
+    data, metadata = dummy_data
+
+    # insert one constant column in data
+    data[data.columns[0]].values[:] = 0
+
+    # init object
+    kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
+    # run kfda test
+    kt.test(verbose=0)
+
+    # insert constant columns in data (except final one)
+    for col in data.columns[:99]:
+        data[col].values[:] = 0
+
+    # init object
+    kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
+    # run kfda test
+    kt.test(verbose=0)
+
+    # insert constant columns in data (all)
+    data[data.columns[99]].values[::2] = 0
+
+    if nystrom:  # not subsampling otherwise and thus no issue
+        err_msg = "Subsampling failed after 100 trials. " + \
+            "All variables have constant values in at leat one subsample."
+        with pytest.raises(RuntimeError) as excinfo:
+            # init object
+            kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
+            # run kfda test
+            kt.test(verbose=0)
+        assert str(excinfo.value) == err_msg
+    else:
+        # init object
+        kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
+        # run kfda test
+        kt.test(verbose=0)
+
+
+@pytest.mark.parametrize("nystrom", [False, True])
+def test_zi_data(dummy_zidata, data_shape, nystrom):
+    """Testing the case of data with zero-inflation."""
+
+    # init object
+    kt = Ktest(data=dummy_zidata[0], metadata=dummy_zidata[1], nystrom=nystrom)
+    # run kfda test
+    kt.test(verbose=0)

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,0 +1,84 @@
+import pytest
+
+from ktest.utils import verbosity
+
+
+def test_verbosity(capsys, recwarn):
+    """Test function managing verbosity output."""
+
+    # no output
+    msg = "no output"
+    verbosity(msg, msg_type="print", verbose=0)
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    msg = "no output"
+    verbosity(msg, msg_type="warning", verbose=0)
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    # print only output
+    msg = "print only"
+    verbosity(msg, msg_type="print", verbose=1)
+    captured = capsys.readouterr()
+    assert captured.out == f"{msg}\n"
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    msg = "print only"
+    verbosity(msg, msg_type="warning", verbose=1)
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    # print or warning output
+    msg = "this is a print"
+    verbosity(msg, msg_type="print", verbose=2)
+    captured = capsys.readouterr()
+    assert captured.out == f"{msg}\n"
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    msg = "this is a warning"
+    with pytest.warns(UserWarning, match=msg):
+        verbosity(msg, msg_type="warning", verbose=2)
+        captured = capsys.readouterr()
+        assert captured.out == ''
+        assert captured.err == ''
+
+    # boolean verbosity level
+    msg = "no output"
+    verbosity(msg, msg_type="print", verbose=False)
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    msg = "print only"
+    verbosity(msg, msg_type="print", verbose=True)
+    captured = capsys.readouterr()
+    assert captured.out == f"{msg}\n"
+    assert captured.err == ''
+    assert len(recwarn) == 0
+
+    # check bad input
+    err_msg = "`msg` input should be a character string"
+    with pytest.raises(AssertionError) as excinfo:
+        verbosity(msg=111, msg_type="print", verbose=0)
+    assert str(excinfo.value) == err_msg
+
+    err_msg = "`msg_type` input should be either \"print\" or \"warning\""
+    with pytest.raises(AssertionError) as excinfo:
+        verbosity(msg="this is a message", msg_type="error", verbose=0)
+    assert str(excinfo.value) == err_msg
+
+    err_msg = "`verbosity` input should be a boolean or an integer value"
+    with pytest.raises(AssertionError) as excinfo:
+        verbosity(msg="this is a message", msg_type="print", verbose="0")
+    assert str(excinfo.value) == err_msg
+


### PR DESCRIPTION
Fix Nystrom subsampling to avoid the case of all variables being null in one group + additional improvements (especially in tests)

* 7c7130c bump package version
* 10cb96e slight improvement of tests, especially regarding input data
* f22a90c minor fix in a docstring
* 7963e82 global warning management depending on verbosity
* 55ac63e fix minor syntax issue in docstring
* 646e55e minor refactoring of data class: dedicated functions to process input data and subsample, check to avoid that all variables are constant after subsampling, unit test improvement (one function to check data object content, multiple data input characteristics, including zero-inflation, constant variables)
* fedfe30 function to manage verbosity output depending on verbosity level chosen by user (+corresponding test)