### PR TITLE
Implement projection with new observations, kFDA prediction and cross-validation

### DIFF
--- a/python/dev/dev_kfda_predict.py
+++ b/python/dev/dev_kfda_predict.py
@@ -1,0 +1,117 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from sklearn.decomposition import PCA
+import torch as to
+
+from ktest.data import Data
+from ktest.kernel_statistics import Statistics
+from ktest.tester import Ktest
+
+
+# data shape
+data_shape = [1000, 100]
+
+# generate random data with different mean in different the 2 groups
+rng = np.random.default_rng(42)
+loc = 0
+# loc = np.hstack([
+#     np.tile(
+#         np.array([-2, 2])[np.arange(data_shape[0]) % 2][:, np.newaxis],
+#         (1, 10)
+#     ) + rng.normal(loc=0, scale=1, size=[data_shape[0], 10]),
+#     np.zeros([data_shape[0], data_shape[1] - 10], dtype=np.float64)
+# ])
+data_array = rng.normal(loc=loc, scale=2, size=data_shape)
+
+# create a data frame from random gaussian data
+data = pd.DataFrame(
+    data=data_array,
+    columns=[f"col{i+1}" for i in range(data_shape[1])]
+)
+
+# create meta data frame indicating two groups
+meta = pd.Series(
+    data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+)
+
+# heatmap of the data matrix
+plt.figure()
+sns.heatmap(pd.concat(
+    [data.iloc[::2], data.iloc[1::2]], ignore_index=True
+))
+plt.savefig("data.png")
+
+# Perform PCA
+pca = PCA(n_components=2)
+transformed_data = pca.fit_transform(data)
+
+print(f"PCA explained variance ratio: {pca.explained_variance_ratio_}")
+
+# plot PCA
+data2plot = pd.DataFrame(transformed_data, columns=['PC1', 'PC2'])
+data2plot["meta"] = meta
+plt.figure()
+sns.scatterplot(data=data2plot, x='PC1', y='PC2', hue="meta")
+plt.savefig("pca.png")
+
+# Kernel test
+kt = Ktest(
+    data=data, metadata=meta, nystrom=False, dtype=to.float64
+)
+kt.test(verbose=0)
+
+print(f"pvalues =\n{kt.kfda_pval_asymp.to_numpy().T[:10]}")
+
+# plot density
+plt.figure()
+kt.plot_density(t=10)
+plt.savefig("density.png")
+
+# ktest data
+data_obj = Data(
+    data=data,
+    metadata=meta,
+    sample_names=None,
+    nystrom=False,
+    dtype=to.float64
+)
+
+# kernel stat object
+kstat = Statistics(
+    data=data_obj,
+    kernel_function='gauss',
+    bandwidth='median',
+    median_coef=1,
+    eps=None, clip_eigval=True
+)
+
+# compute stat
+stat_val, _ = kstat.compute_kfda()
+
+print(f"Stat value =\n{stat_val.to_numpy().T[:10]}")
+
+# compute projections
+proj_kfda, proj_kpca = kstat.compute_projections(
+    stat=stat_val, t=50, center=False
+)
+
+# plot projection
+data2plot = pd.concat(proj_kfda.values()).sort_index().rename(
+    lambda x: f"t{x}", axis="columns"
+)
+data2plot["meta"] = meta
+plt.figure()
+sns.kdeplot(data=data2plot, x="t50", hue="meta")
+plt.savefig("proj.png")
+
+# prediction
+pred, loss = kstat.kfda_predict(t=50, pred_threshold=0)
+
+# compute accuracy
+for group in kstat.data.data.keys():
+    n_obs = kstat.data.data[group].shape[0]
+    count_pred = np.count_nonzero(pred[group] == group, axis=0)
+    print(f"Prediction accuracy for group '{group}': {count_pred / n_obs}")
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.1.2"
+version = "1.2.0"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,5 +52,7 @@ include-package-data = false
 dev = [
     "ipython>=7.16.3",
     "pytest>=7.0.1",
+    "scikit-learn>=0.24.2",
+    "seaborn>=0.11.2",
     "toml>=0.10.2",
 ]

--- a/python/src/ktest/data.py
+++ b/python/src/ktest/data.py
@@ -170,7 +170,7 @@ class Data(object):
             if not (hasattr(data, 'index') or hasattr(metadata, 'index')):
                 assrt_str_1 = 'If index is not provided, ' + \
                     'data and metadata have to have the same first dimension.'
-                assert data.shape[0] == data.shape, assrt_str_1
+                assert data.shape[0] == metadata.shape[0], assrt_str_1
             if isinstance(metadata, pd.DataFrame):
                 meta_fmt = metadata[metadata.columns[0]]
             else:

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -858,7 +858,7 @@ class Statistics(object):
             )
         return proj_kfda, proj_kpca
 
-    def kfda_loss(self, t=100, new_obs=None):
+    def kfda_loss(self, t=100, new_obs=None, stat=None):
         """
         Compute the two compartments (one for each group) of the kFDA loss
         function associated to the prediction for each observations (either in
@@ -878,6 +878,12 @@ class Statistics(object):
             Unused by default. If not None, then the loss function for the
             `new_obs` data are computed.
 
+        stat : Pandas.Series, optional
+            kFDA statistics (same as the attribute `kfda_statistic` of class
+            Ktest). Required for projection normalization. Can be provided as
+            input argument to avoid re-computing it. If `None` (default), then
+            the kFDA statistics is re-computed.
+
         Returns
         -------
 
@@ -895,7 +901,8 @@ class Statistics(object):
         """
 
         # get kFDA stat Value
-        stat, _ = self.compute_kfda()
+        if stat is None:
+            stat, _ = self.compute_kfda()
 
         # compute kfda projection for training data
         proj_kfda, _ = self.compute_projections(
@@ -937,7 +944,7 @@ class Statistics(object):
         # output
         return distance_group1, distance_group2
 
-    def kfda_predict(self, t=100, new_obs=None, pred_threshold=0.5):
+    def kfda_predict(self, t=100, new_obs=None, pred_threshold=0.5, stat=None):
         """
         Compute prediction for each observations according to kFDA, i.e.
         assign each observations to one of the two groups depending on
@@ -960,6 +967,12 @@ class Statistics(object):
             predicting only second group. Default value is `0.5` and no bias is
             introduced. Useful for ROC curve and AUC computations.
             If Iterable, the prediction is computed for each threshold value.
+
+        stat : Pandas.Series, optional
+            kFDA statistics (same as the attribute `kfda_statistic` of class
+            Ktest). Required for projection normalization. Can be provided as
+            input argument to avoid re-computing it. If `None` (default), then
+            the kFDA statistics is re-computed.
 
         Returns
         -------
@@ -996,7 +1009,7 @@ class Statistics(object):
                 raise ValueError(msg)
 
         # compute loss function associated to kFDA prediction
-        distance_group1, distance_group2 = self.kfda_loss(t, new_obs)
+        distance_group1, distance_group2 = self.kfda_loss(t, new_obs, stat)
 
         # init output (list of dictionaries)
         pred = []

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -412,12 +412,21 @@ class Statistics(object):
             K = self.kernel(D, D)
         return K
 
-    def compute_kmn(self):
+    def compute_kmn(self, new_obs=None):
         """
         Computes an (nxanchors+nyanchors)x(ndata) conversion gram matrix.
 
+        Parameters
+        ----------
+            new_obs : torch.tensor, optional
+                Unused by default. If not None, then the Gram matrix between
+                landmarks and `new_obs` is computed.
+
         """
-        data = cat([x for x in self.data.data.values()], axis=0)
+        if new_obs is not None:
+            data = new_obs
+        else:
+            data = cat([x for x in self.data.data.values()], axis=0)
         landmarks = cat([x for x in self.data_ny.data.values()], axis=0)
         kmn = self.kernel(landmarks, data)
         return kmn

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -377,7 +377,7 @@ class Statistics(object):
         m_mu2 = 1/n2 * ones(n2, dtype=self.dtype)
         return cat((m_mu1, m_mu2), dim=0)
 
-    def compute_gram(self, landmarks=False):
+    def compute_gram(self, landmarks=False, new_obs=None):
         """
         Computes the Gram matrix of the data in question.
 
@@ -391,6 +391,9 @@ class Statistics(object):
             landmarks : bool, optional
                 False by default. If True, performs the computations on the
                 the Nystrom dataset (landmarks).
+            new_obs : torch.tensor, optional
+                Unused by default. If not None, then the Gram matrix between
+                data and `new_obs` is computed.
 
         Returns
         -------
@@ -403,7 +406,10 @@ class Statistics(object):
             )
         data = self.data if not landmarks else self.data_ny
         D = cat([x for x in data.data.values()], axis=0)
-        K = self.kernel(D, D)
+        if new_obs is not None:
+            K = self.kernel(D, new_obs)
+        else:
+            K = self.kernel(D, D)
         return K
 
     def compute_kmn(self):

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -792,9 +792,9 @@ class Statistics(object):
         upk = self.compute_upk(t)
         n1, n2 = self.data.nobs.values()
         n = self.data.ntot
+        centering_mat = eye(n, dtype=self.dtype)
         if center:
-            centering_mat = eye(n, dtype=self.dtype)
-            centering_mat -= ones((n, n)) / n
+            centering_mat -= ones((n, n), dtype=self.dtype) / n
         proj = ((self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
                  * matmul(centering_mat, upk)).numpy())
         proj_list = [proj[:n1], proj[n1:]]

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -718,7 +718,7 @@ class Statistics(object):
             mmd = dot(mv(K, m), m) ** 2
         return mmd.item()
 
-    def compute_upk(self, t):
+    def compute_upk(self, t, new_obs=None):
         """
         epk is an alias for the product ePK that appears when projecting the
         data on the discriminant axis. This functions computes the
@@ -727,26 +727,35 @@ class Statistics(object):
         warning: some work remains to be done to :
             - normalize the vectors with respect to n_anchors as in pkm
             - separate the different nystrom approaches
+        FIXME: seems to be ok
+
+        Parameters
+        ----------
+            t : int
+                Maximal truncation.
+            new_obs : torch.tensor, optional
+                Unused by default. If not None, then the Gram matrix between
+                landmarks and `new_obs` is computed.
         """
         if self.sp is None and self.ev is None:
             self.sp, self.ev = self.diagonalize_centered_gram()
         if self.data_ny is not None:
-            Kzx = self.compute_kmn()
+            Kzx = self.compute_kmn(new_obs=new_obs)
             if self.sp_anchors is None and self.ev_anchors is None:
                 self.sp_anchors, self.ev_anchors = \
                     self.compute_nystrom_anchors()
             Lz12 = diag(self.sp_anchors**-(1/2))
-            epk = 1 / self.data_ny.ntot**(1/2) * multi_dot([self.ev.T[:t],
-                                                            Lz12,
-                                                            self.ev_anchors.T,
-                                                            Kzx]).T
+            epk = 1 / self.data_ny.ntot**(1/2) * \
+                multi_dot([
+                    self.ev.T[:t], Lz12, self.ev_anchors.T, Kzx
+                ]).T
         else:
             Pbi = self.compute_centering_matrix()
-            Kx = self.compute_gram()
+            Kx = self.compute_gram(new_obs=new_obs)
             epk = multi_dot([self.ev.T[:t], Pbi, Kx]).T
         return epk
 
-    def compute_projections(self, stat, t=100, center=True):
+    def compute_projections(self, stat, t=100, center=True, new_obs=None):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -761,16 +770,19 @@ class Statistics(object):
         ----------
 
         stat : Pandas.Series
+            kFDA statistics (same as the attribute `kfda_statistic` of class
+            Ktest). Required for normalization.
 
         t : int, optional
             Maximal truncation, the default is 100.
 
-            kFDA statistics (same as the attribute `kfda_statistic` of class
-            Ktest). Required for normalization.
-
         center : bool, optional
             If True (default), the projections are centered with respect to
             the mean embedding.
+
+        new_obs : torch.tensor, optional
+            Unused by default. If not None, then the projections for the
+            `new_obs` data are computed.
 
         Returns
         -------
@@ -785,22 +797,45 @@ class Statistics(object):
             cumulated sum of the values in 'proj_kpca'.
 
         """
+        # diagonalize centered Gram matrix if needed
         if self.sp is None and self.ev is None:
             self.sp, self.ev = self.diagonalize_centered_gram()
+        # fix truncation if needed
         t = min(t, len(self.sp))
+        # compute intermediate quantities
         pkm = self.compute_pkm()
-        upk = self.compute_upk(t)
+        upk = self.compute_upk(t, new_obs=new_obs)
+        # number of observations in training data
         n1, n2 = self.data.nobs.values()
         n = self.data.ntot
-        centering_mat = eye(n, dtype=self.dtype)
+        # number of observations in projected data
+        if new_obs is not None:
+            n_obs = new_obs.shape[0]
+        else:
+            n_obs = n
+        # define centering matrix (identity if no centering)
+        centering_mat = eye(n_obs, dtype=self.dtype)
         if center:
-            centering_mat -= ones((n, n), dtype=self.dtype) / n
+            centering_mat -= ones((n_obs, n_obs), dtype=self.dtype) / n_obs
+        # compute projections
         proj = ((self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
                  * matmul(centering_mat, upk)).numpy())
-        proj_list = [proj[:n1], proj[n1:]]
+        # post-processing
+        # (manage training data vs new obsercations differently)
+        if new_obs is not None:
+            proj_list = [proj]
+        else:
+            proj_list = [proj[:n1], proj[n1:]]
+        # init output
         proj_kfda = {}
         proj_kpca = {}
-        for i, (name, ind) in enumerate(self.data.index.items()):
+        # group index (create a new one for new_obs if needed)
+        if new_obs is not None:
+            index_dict = {"new_obs": pd.Index(range(new_obs.shape[0]))}
+        else:
+            index_dict = self.data.index
+        # iterate through groups
+        for i, (name, ind) in enumerate(index_dict.items()):
             proj_kpca[name] = pd.DataFrame(
                 proj_list[i], index=ind,
                 columns=[str(t) for t in range(1, t+1)]

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -414,7 +414,7 @@ class Statistics(object):
 
     def compute_kmn(self, new_obs=None):
         """
-        Computes an (nxanchors+nyanchors)x(ndata) conversion gram matrix.
+        Computes an (nxlandmarks+nylandmarks)x(ndata) conversion gram matrix.
 
         Parameters
         ----------

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -977,21 +977,19 @@ class Statistics(object):
         Returns
         -------
 
-        pred: dict or list of dict
-            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
-            kFDA predictions for each observation and increasing truncation,
+        pred: dict
+            dictionary containing list of prediction arrays (np.ndarray),
             either for each group in the training data or for the new
-            observations. If `pred_threshold` input argument is an Iterable,
-            then `pred` is a list corresponding to prediction dictionaries for
-            each element in `pred_threshold`.
+            observations, each array stores kFDA predictions for each
+            considered observation and increasing truncation values, for a
+            given prediction threshold given by `pred_threshold`.
 
-        loss: dict or list of dict
-            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
-            kFDA loss function values for each observation and increasing
-            truncation, either for each group in the training data or for the
-            new observations. If `pred_threshold` input argument is an
-            Iterable, then `pred` is a list corresponding to prediction
-            dictionaries for each element in `pred_threshold`.
+        loss: dict
+            dictionary containing list of loss value arrays (np.ndarray),
+            either for each group in the training data or for the new
+            observations, each array stores kFDA loss function values for each
+            considered observation and increasing truncation values, for a
+            given prediction threshold given by `pred_threshold`.
         """
 
         # check threshold input and convert to list if scalar
@@ -1011,27 +1009,29 @@ class Statistics(object):
         # compute loss function associated to kFDA prediction
         distance_group1, distance_group2 = self.kfda_loss(t, new_obs, stat)
 
-        # init output (list of dictionaries)
-        pred = []
-        loss = []
+        # init output (dictionaries)
+        pred = {}
+        loss = {}
 
-        # iterate through threshold value
-        for thres_val in pred_threshold:
+        # compute prediction for each observation set
+        # iterate through group (or new obs)
+        for i, (group, dist_g1, dist_g2) in enumerate(zip(
+            distance_group1.keys(),
+            distance_group1.values(),
+            distance_group2.values()
+        )):
+            # init intermediate results (for each threshold value)
+            pred_inter = []
+            loss_inter = []
 
-            # init intermediate results
-            pred_inter = {}
-            loss_inter = {}
+            # compare distances to group 1 and group 2
+            diff_g1_g2 = dist_g1 - dist_g2
 
-            # compute prediction for each observation set
-            # iterate through group (or new obs)
-            for i, (group, dist_g1, dist_g2) in enumerate(zip(
-                distance_group1.keys(),
-                distance_group1.values(),
-                distance_group2.values()
-            )):
+            # iterate through threshold value
+            for thres_val in pred_threshold:
 
-                # prediction loss
-                loss_val = dist_g1 - dist_g2 - \
+                # compute loss value
+                loss_val = diff_g1_g2 - \
                     pred_threshold_fun(thres_val, dist_g2, dist_g1)
                 # loss > 0 ?
                 # loss < 0 -> group 1
@@ -1042,16 +1042,12 @@ class Statistics(object):
                 pred_val = group_name[(1 - (loss_val < 0).int()).numpy()]
 
                 # store prediction and loss for current set of observations
-                pred_inter[group] = pred_val
-                loss_inter[group] = loss_val.numpy()
+                pred_inter.append(pred_val)
+                loss_inter.append(loss_val.numpy())
 
             # store results
-            pred.append(pred_inter)
-            loss.append(loss_inter)
-
-        if len(pred_threshold) == 1:
-            pred = pred[0]
-            loss = loss[0]
+            pred[group] = pred_inter
+            loss[group] = loss_inter
 
         # output
         return pred, loss

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -813,13 +813,18 @@ class Statistics(object):
             n_obs = new_obs.shape[0]
         else:
             n_obs = n
-        # define centering matrix (identity if no centering)
-        centering_mat = eye(n_obs, dtype=self.dtype)
-        if center:
-            centering_mat -= ones((n_obs, n_obs), dtype=self.dtype) / n_obs
         # compute projections
-        proj = ((self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
-                 * matmul(centering_mat, upk)).numpy())
+        if center:
+            # define centering matrix (identity if no centering)
+            centering_mat = eye(n_obs, dtype=self.dtype) \
+                - ones((n_obs, n_obs), dtype=self.dtype) / n_obs
+            # project
+            proj = (self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
+                    * matmul(centering_mat, upk)).numpy()
+        else:
+            # project
+            proj = (self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
+                    * upk).numpy()
         # post-processing
         # (manage training data vs new obsercations differently)
         if new_obs is not None:

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -1,10 +1,10 @@
+import warnings
 import numpy as np
 import pandas as pd
 from torch import cdist, cat, matmul, exp, mv, dot, diag, sqrt
 from torch import ones, eye, zeros, finfo
-import torch as t
+import torch as to
 from torch.linalg import multi_dot, eigh
-import warnings
 
 
 def distances(x, y=None):
@@ -495,13 +495,13 @@ class Statistics(object):
                         multi_dot([
                             Kmn[:, :sample_size[0]],
                             Kmn[:, :sample_size[0]].T - 1/sample_size[0] *
-                            t.sum(Kmn[:, :sample_size[0]], dim=1)
+                            to.sum(Kmn[:, :sample_size[0]], dim=1)
                             # use pytorch broadcasting
                         ]) +
                         multi_dot([
                             Kmn[:, -sample_size[1]:],
                             Kmn[:, -sample_size[1]:].T - 1/sample_size[1] *
-                            t.sum(Kmn[:, -sample_size[1]:], dim=1)
+                            to.sum(Kmn[:, -sample_size[1]:], dim=1)
                             # use pytorch broadcasting
                         ]),
                         Pm,

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+from numbers import Real
 import warnings
 import numpy as np
 import pandas as pd
@@ -5,6 +7,8 @@ from torch import cdist, cat, matmul, exp, mv, dot, diag, sqrt
 from torch import ones, eye, zeros, finfo
 import torch as to
 from torch.linalg import multi_dot, eigh
+
+from .utils import pred_threshold_fun
 
 
 def distances(x, y=None):
@@ -853,3 +857,188 @@ class Statistics(object):
                 n ** 3 * stat.values[:t] / (n1 * n2)
             )
         return proj_kfda, proj_kpca
+
+    def kfda_loss(self, t=100, new_obs=None):
+        """
+        Compute the two compartments (one for each group) of the kFDA loss
+        function associated to the prediction for each observations (either in
+        training data or for provided new observations) depending on kFDA axis
+        projection.
+
+        The loss is the difference between the distance to each group mean
+        embedding. The function computes each element of this difference.
+
+        Parameters
+        ----------
+
+        t: int, optional
+            Maximal truncation, the default is 100.
+
+        new_obs: torch.tensor, optional
+            Unused by default. If not None, then the loss function for the
+            `new_obs` data are computed.
+
+        Returns
+        -------
+
+        distance_group1: dict
+            dictionary of arrays (torch.Tensor) storing the distance from each
+            observation to the mean embedding of group 1 for increasing
+            truncation, either for each group in the training data or for the
+            new observations.
+
+        distance_group2: dict
+            dictionary of arrays (torch.Tensor) storing the distance from each
+            observation to the mean embedding of group 2 for increasing
+            truncation, either for each group in the training data or for the
+            new observations.
+        """
+
+        # get kFDA stat Value
+        stat, _ = self.compute_kfda()
+
+        # compute kfda projection for training data
+        proj_kfda, _ = self.compute_projections(
+            stat, t, center=False, new_obs=None
+        )
+
+        # compute mean embedding for training data (in the two groups)
+        mean_embed = []
+        for group in proj_kfda.keys():
+            mean_embed.append(proj_kfda[group].mean(axis=0))
+        mean_embed = pd.DataFrame(mean_embed)
+        # cast back to torch object
+        mean_embed = to.from_numpy(mean_embed.values)
+
+        # if new observation, compute corresponding projection
+        if new_obs is not None:
+            proj_kfda, _ = self.compute_projections(
+                stat, t, center=False, new_obs=new_obs
+            )
+
+        # init output
+        distance_group1 = {}
+        distance_group2 = {}
+
+        # compute loss function compartments for each observation set
+        # iterate through group (or new obs)
+        for i, (group, proj_tab) in enumerate(proj_kfda.items()):
+
+            # cast back to torch object
+            proj_tab = to.from_numpy(proj_tab.values)
+
+            # distance to each group
+            distance_g1_val = to.abs(proj_tab - mean_embed[0,:])  # group 1
+            distance_g2_val = to.abs(proj_tab - mean_embed[1,:])  # group 2
+
+            distance_group1[group] = distance_g1_val
+            distance_group2[group] = distance_g2_val
+
+        # output
+        return distance_group1, distance_group2
+
+    def kfda_predict(self, t=100, new_obs=None, pred_threshold=0.5):
+        """
+        Compute prediction for each observations according to kFDA, i.e.
+        assign each observations to one of the two groups depending on
+        kFDA axis projection.
+
+        Parameters
+        ----------
+
+        stat : Pandas.Series
+            kFDA statistics (same as the attribute `kfda_statistic` of class
+            Ktest). Required for normalization.
+
+        t : int, optional
+            Maximal truncation, the default is 100.
+
+        pred_threshold : float or Iterable, optional
+            Number (or Iterable containing numbers) between `0` an 1 to bias
+            prediction towards first group or second group (in appearence order
+            in the data). `0` means predicting only first group and `1`
+            predicting only second group. Default value is `0.5` and no bias is
+            introduced. Useful for ROC curve and AUC computations.
+            If Iterable, the prediction is computed for each threshold value.
+
+        Returns
+        -------
+
+        pred: dict or list of dict
+            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
+            kFDA predictions for each observation and increasing truncation,
+            either for each group in the training data or for the new
+            observations. If `pred_threshold` input argument is an Iterable,
+            then `pred` is a list corresponding to prediction dictionaries for
+            each element in `pred_threshold`.
+
+        loss: dict or list of dict
+            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
+            kFDA loss function values for each observation and increasing
+            truncation, either for each group in the training data or for the
+            new observations. If `pred_threshold` input argument is an
+            Iterable, then `pred` is a list corresponding to prediction
+            dictionaries for each element in `pred_threshold`.
+        """
+
+        # check threshold input and convert to list if scalar
+        msg = "'pred_threshold' should be a number or an iterable " + \
+            "containing numbers between 0 and 1"
+        if not isinstance(pred_threshold, (Real, Iterable)):
+            raise TypeError(msg)
+        if not isinstance(pred_threshold, Iterable):
+            pred_threshold = [pred_threshold]
+            if not all(
+                isinstance(item, Real) and
+                item >= 0 and item <= 1
+                for item in pred_threshold
+            ):
+                raise ValueError(msg)
+
+        # compute loss function associated to kFDA prediction
+        distance_group1, distance_group2 = self.kfda_loss(t, new_obs)
+
+        # init output (list of dictionaries)
+        pred = []
+        loss = []
+
+        # iterate through threshold value
+        for thres_val in pred_threshold:
+
+            # init intermediate results
+            pred_inter = {}
+            loss_inter = {}
+
+            # compute prediction for each observation set
+            # iterate through group (or new obs)
+            for i, (group, dist_g1, dist_g2) in enumerate(zip(
+                distance_group1.keys(),
+                distance_group1.values(),
+                distance_group2.values()
+            )):
+
+                # prediction loss
+                loss_val = dist_g1 - dist_g2 - \
+                    pred_threshold_fun(thres_val, dist_g2, dist_g1)
+                # loss > 0 ?
+                # loss < 0 -> group 1
+                # loss > 0 -> group 2
+
+                # convert loss to group name prediction
+                group_name = np.array(list(self.data.index.keys()))
+                pred_val = group_name[(1 - (loss_val < 0).int()).numpy()]
+
+                # store prediction and loss for current set of observations
+                pred_inter[group] = pred_val
+                loss_inter[group] = loss_val.numpy()
+
+            # store results
+            pred.append(pred_inter)
+            loss.append(loss_inter)
+
+        if len(pred_threshold) == 1:
+            pred = pred[0]
+            loss = loss[0]
+
+        # output
+        return pred, loss

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -946,19 +946,19 @@ class Statistics(object):
 
     def kfda_predict(self, t=100, new_obs=None, pred_threshold=0.5, stat=None):
         """
-        Compute prediction for each observations according to kFDA, i.e.
-        assign each observations to one of the two groups depending on
-        kFDA axis projection.
+        Compute prediction for each observations according to kFDA and with
+        increasing truncation values, i.e. assign each observations to one of
+        the two groups using projections on kFDA axis.
 
         Parameters
         ----------
 
-        stat : Pandas.Series
-            kFDA statistics (same as the attribute `kfda_statistic` of class
-            Ktest). Required for normalization.
-
         t : int, optional
             Maximal truncation, the default is 100.
+
+        new_obs: torch.tensor, optional
+            Unused by default. If not None, then the prediction for the
+            `new_obs` data is computed.
 
         pred_threshold : float or Iterable, optional
             Number (or Iterable containing numbers) between `0` an 1 to bias

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -6,12 +6,14 @@ from matplotlib import rc
 import numpy as np
 import pandas as pd
 from scipy.stats import chi2, gaussian_kde
+from sklearn.model_selection import RepeatedStratifiedKFold
 from torch import float64
 import torch as to
 from tqdm import tqdm
 
 from .data import Data
 from .kernel_statistics import Statistics
+from .utils import compute_accuracy
 
 
 class Ktest(Statistics):
@@ -540,6 +542,290 @@ class Ktest(Statistics):
 
             # output
             return kfda_proj, kfda_proj_contrib
+
+    def predict(self, t=100, new_obs=None, pred_threshold=0.5, verbose=1):
+        """
+        Compute prediction for each observations according to kFDA and with
+        increasing truncation values, i.e. assign each observations to one of
+        the two groups using projections on kFDA axis.
+
+        Parameters
+        ----------
+
+        t : int, optional
+            Maximal truncation, the default is 100.
+
+        new_obs: array-like, pandas.DataFrame or torch.Tensor or numpy.array,
+            optional
+            Unused by default. If not None, then the prediction for the
+            `new_obs` data is computed.
+
+        pred_threshold : float or Iterable, optional
+            Number (or Iterable containing numbers) between `0` an 1 to bias
+            prediction towards first group or second group (in appearence order
+            in the data). `0` means predicting only first group and `1`
+            predicting only second group. Default value is `0.5` and no bias is
+            introduced. Useful for ROC curve and AUC computations.
+            If Iterable, the prediction is computed for each threshold value.
+
+        verbose : int, optional
+            The higher the verbosity, the more messages keeping track of
+            computations. The default is 1.
+            - < 1: no messages,
+            - 1: progress bar with computation time,
+            - 2: warnings are printed once,
+            - 3: warnings are printed every time they appear.
+
+        Returns
+        -------
+
+        pred: dict or list of dict
+            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
+            kFDA predictions for each observation and increasing truncation,
+            either for each group in the training data or for the new
+            observations. If `pred_threshold` input argument is an Iterable,
+            then `pred` is a list corresponding to prediction dictionaries for
+            each element in `pred_threshold`.
+
+        loss: dict or list of dict
+            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
+            kFDA loss function values for each observation and increasing
+            truncation, either for each group in the training data or for the
+            new observations. If `pred_threshold` input argument is an
+            Iterable, then `pred` is a list corresponding to prediction
+            dictionaries for each element in `pred_threshold`.
+        """
+
+        with warnings.catch_warnings():
+            if verbose < 2:
+                warnings.simplefilter("ignore")
+            elif verbose >= 3:
+                warnings.simplefilter("always")
+
+            # compute statistic if needed
+            if self.kfda_statistic is None:
+                self.test(stat='kfda')
+
+            # check new_obs input convert and to torch.Tensor
+            if new_obs is not None:
+                if not (
+                    isinstance(new_obs, pd.DataFrame) or
+                    isinstance(new_obs, np.ndarray) or
+                    isinstance(new_obs, to.Tensor)
+                ) and new_obs.shape[1] != self.dataset.shape[1]:
+                    msg = "'new_obs' should be an array-like object with " + \
+                        "the same number of columns as the original " + \
+                        "training data."
+                    raise ValueError(msg)
+
+                if isinstance(new_obs, pd.DataFrame):
+                    new_obs = to.from_numpy(new_obs.to_numpy())
+                elif isinstance(new_obs, np.ndarray):
+                    new_obs = to.from_numpy(new_obs)
+
+            # compute prediction
+            kfda_pred, kfda_loss = self.kstat.kfda_predict(
+                t=t, new_obs=new_obs, pred_threshold=pred_threshold,
+                stat=self.kfda_statistic
+            )
+
+            # output
+            return kfda_pred, kfda_loss
+
+    def cv(
+        self, t=100, pred_threshold=0.5, n_fold=5, n_repeat=1, ref=None,
+        random_state=None, verbose=1
+    ):
+        """
+        Compute prediction and prediction error by V-fold cross-validation,
+        for each observations according to kFDA and with increasing truncation
+        values.
+
+        Parameters
+        ----------
+
+        t : int, optional
+            Maximal truncation, the default is 100.
+
+        pred_threshold : float or Iterable, optional
+            Number (or Iterable containing numbers) between `0` an 1 to bias
+            prediction towards first group or second group (in appearence order
+            in the data). `0` means predicting only first group and `1`
+            predicting only second group. Default value is `0.5` and no bias is
+            introduced. Useful for ROC curve and AUC computations.
+            If Iterable, the prediction is computed for each threshold value.
+
+        n_fold : int, default=5
+            Number of folds in cross-validation. Should be at least 2.
+
+        n_repeat : int, default=1
+            Number of times cross-validation will be repeated.
+
+        ref : str or None, default=None
+            Reference group/class/subsample for computing true positive rates.
+            The other group/class/subsample will be used for computing true
+            negative rate.
+            `ref` should be among input metadata. If None, then the reference
+            is chosen to be the first group by order of appearence in the data.
+
+        random_state : int, numpy.random.RandomState or None, default=None
+            Controls the generation of the random states for cross-validation
+            subsampling. Pass an int for reproducible output across multiple
+            function calls.
+
+        verbose : int, optional
+            The higher the verbosity, the more messages keeping track of
+            computations. The default is 1.
+            - < 1: no messages,
+            - 1: progress bar with computation time,
+            - 2: warnings are printed once,
+            - 3: warnings are printed every time they appear.
+
+        Returns
+        -------
+
+        accuracy : list of numpy.ndarray
+            list of 1-D arrays of average accuracy over cross-validation
+            for increasing truncation values, corresponding to each prediction
+            threshold bias value(s) provided in input.
+
+        true_pos : list of numpy.ndarray
+            list of 1-D arrays of average true positive rates over
+            cross-validation for increasing truncation values, corresponding
+            to each prediction threshold bias value(s) provided in input.
+        true_neg : numpy.ndarray
+            list of 1-D arrays of average true negative rates over
+            cross-validation for increasing truncation values, corresponding
+            to each prediction threshold bias value(s) provided in input.
+        """
+
+        with warnings.catch_warnings():
+            if verbose < 2:
+                warnings.simplefilter("ignore")
+            elif verbose >= 3:
+                warnings.simplefilter("always")
+
+            # check input
+            if ref is not None and not ref in self.data.sample_names:
+                msg = "`ref` is not a valid class/group/subsample " + \
+                    "reference name."
+                raise ValueError(msg)
+            else:
+                ref = self.data.sample_names[0]
+
+            # compute test statistics if not done
+            if self.kfda_statistic is None:
+                self.test(stat='kfda')
+
+            # cross-validation sub-subsampling
+            cv_setup = RepeatedStratifiedKFold(
+                n_splits=n_fold, n_repeats=n_repeat, random_state=random_state
+            )
+            cv_split = cv_setup.split(self.dataset, self.metadata)
+
+            # init result storage over fold
+            fold_res = []
+
+            # verbosity
+            verbose >= 1 and print(f"Starting cross-validation...")
+
+            # iterate trough data partitions
+            for i, (train_index, test_index) in enumerate(cv_split):
+                verbose >= 1 and print(f"Split {i}")
+
+                # prepare training data
+                train_data = Data(
+                    data=self.dataset.iloc[train_index],
+                    metadata=self.metadata.iloc[train_index],
+                    sample_names=self.sample_names
+                )
+
+                # Nystrom subsampling if needed
+                train_data_nystrom = None
+                if self.data_nystrom is not None:
+                    train_data_nystrom = Data(
+                        data=self.dataset.iloc[train_index],
+                        metadata=self.metadata.iloc[train_index],
+                        sample_names=self.sample_names,
+                        nystrom=True, n_landmarks=self.n_landmarks,
+                        landmark_method=self.landmark_method,
+                        random_state=self.rnd_gen
+                    )
+
+                # define statistic object for training data
+                kstat_perm = Statistics(
+                    train_data,
+                    kernel_function=self.kernel_function,
+                    bandwidth=self.kernel_bandwidth,
+                    median_coef=self.kernel_median_coef,
+                    data_nystrom=train_data_nystrom,
+                    n_anchors=self.n_anchors,
+                    anchor_basis=self.anchor_basis,
+                    eps=self.eps, clip_eigval=self.clip_eigval
+                )
+
+                # compute prediction
+                kfda_pred, kfda_loss = kstat_perm.kfda_predict(
+                    t=t,
+                    new_obs=to.from_numpy(self.dataset.iloc[test_index].to_numpy()),
+                    pred_threshold=pred_threshold,
+                    stat=None
+                )
+
+                # compute accuracy
+                accuracy_res, true_pos_res, true_neg_res = compute_accuracy(
+                    kfda_pred["new_obs"],
+                    self.metadata.iloc[test_index].to_numpy(),
+                    ref=ref
+                )
+
+                # store prediction results
+                fold_res.append({
+                    "accuracy": accuracy_res,
+                    "true_pos": true_pos_res,
+                    "true_neg": true_neg_res,
+                    "test_index": test_index
+                })
+
+            # verbosity
+            verbose >= 1 and print(f"...Aggregating CV fold results")
+
+            # reformat cv result storage
+            # input: `fold_res` is a list of dictionaries containing list of
+            # arrays storing a metric for each pred_threshold values
+            # output: `<metric>_list` is a list of <metric> arrays for each
+            # pred_threshold values
+            # accuracy_list = [
+            #     list(accuracy_tab) for accuracy_tab in
+            #     zip(*[d["accuracy"] for d in fold_res])
+            # ]
+            accuracy_list = list(map(
+                list, zip(*[d["accuracy"] for d in fold_res])
+            ))
+            true_pos_list = list(map(
+                list, zip(*[d["true_pos"] for d in fold_res])
+            ))
+            true_neg_list = list(map(
+                list, zip(*[d["true_neg"] for d in fold_res])
+            ))
+
+            # compute average accuracy, true pos rate and true neg rate over
+            # all folds
+            accuracy = [
+                np.mean(np.vstack(accuracy_tab_list), axis=0)
+                for accuracy_tab_list in accuracy_list
+            ]
+            true_pos = [
+                np.mean(np.vstack(true_pos_tab_list), axis=0)
+                for true_pos_tab_list in true_pos_list
+            ]
+            true_neg = [
+                np.mean(np.vstack(true_neg_tab_list), axis=0)
+                for true_neg_tab_list in true_neg_list
+            ]
+
+            # output
+            return accuracy, true_pos, true_neg
 
     def plot_density(
         self, t=None, t_max=100, colors=None, labels=None, alpha=.5,

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -1,16 +1,16 @@
+import gzip
+import warnings
+import dill
+import matplotlib.pyplot as plt
+from matplotlib import rc
 import numpy as np
 import pandas as pd
 from scipy.stats import chi2, gaussian_kde
-import matplotlib.pyplot as plt
-from matplotlib import rc
-import warnings
-from tqdm import tqdm
-import dill
-import gzip
 from torch import float64
+from tqdm import tqdm
 
-from .kernel_statistics import Statistics
 from .data import Data
+from .kernel_statistics import Statistics
 
 
 class Ktest(Statistics):

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -217,6 +217,8 @@ class Ktest(Statistics):
                 random_state=self.rnd_gen,
                 dtype=dtype
             )
+
+        ### define statistic object
         self.kstat = Statistics(
             self.data, kernel_function=self.kernel_function,
             bandwidth=self.kernel_bandwidth,

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import chi2, gaussian_kde
 from torch import float64
+import torch as to
 from tqdm import tqdm
 
 from .data import Data
@@ -460,7 +461,7 @@ class Ktest(Statistics):
                     "Possible values : 'kfda','mmd'"
                 )
 
-    def project(self, t=100, center=True, verbose=1, new_obs=None):
+    def project(self, t=100, center=True, new_obs=None, verbose=1):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -477,9 +478,18 @@ class Ktest(Statistics):
             If True (default), the projections are centered with respect to
             the mean embedding.
 
-        new_obs : torch.tensor, optional
+        new_obs: array-like, pandas.DataFrame or torch.Tensor or numpy.array,
+            optional
             Unused by default. If not None, then the projections for the
-            `new_obs` data are computed.
+            `new_obs` data is computed.
+
+        verbose : int, optional
+            The higher the verbosity, the more messages keeping track of
+            computations. The default is 1.
+            - < 1: no messages,
+            - 1: progress bar with computation time,
+            - 2: warnings are printed once,
+            - 3: warnings are printed every time they appear.
 
         Returns
         -------
@@ -502,11 +512,27 @@ class Ktest(Statistics):
             if self.kfda_statistic is None:
                 self.test(stat='kfda')
 
+            # check new_obs input convert and to torch.Tensor
+            if new_obs is not None:
+                if not (
+                    isinstance(new_obs, pd.DataFrame) or
+                    isinstance(new_obs, np.ndarray) or
+                    isinstance(new_obs, to.Tensor)
+                ) and new_obs.shape[1] != self.dataset.shape[1]:
+                    msg = "'new_obs' should be an array-like object with " + \
+                        "the same number of columns as the original " + \
+                        "training data."
+                    raise ValueError(msg)
+
+                if isinstance(new_obs, pd.DataFrame):
+                    new_obs = to.from_numpy(new_obs.to_numpy())
+                elif isinstance(new_obs, np.ndarray):
+                    new_obs = to.from_numpy(new_obs)
+
             # compute projections
-            kfda_proj, kfda_proj_contrib = \
-                self.kstat.compute_projections(
-                    self.kfda_statistic, t=t, center=center, new_obs=new_obs
-                )
+            kfda_proj, kfda_proj_contrib = self.kstat.compute_projections(
+                self.kfda_statistic, t=t, center=center, new_obs=new_obs
+            )
 
             # record projections only when projecting training data
             self.kfda_proj = kfda_proj

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -460,7 +460,7 @@ class Ktest(Statistics):
                     "Possible values : 'kfda','mmd'"
                 )
 
-    def project(self, t=100, center=True, verbose=1):
+    def project(self, t=100, center=True, verbose=1, new_obs=None):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -477,6 +477,21 @@ class Ktest(Statistics):
             If True (default), the projections are centered with respect to
             the mean embedding.
 
+        new_obs : torch.tensor, optional
+            Unused by default. If not None, then the projections for the
+            `new_obs` data are computed.
+
+        Returns
+        -------
+
+        proj_kfda : pandas.DataFrame
+            Projections associated with every observation (rows) on every
+            eigendirection (columns).
+
+        proj_kpca : pandas.DataFrame
+            Contributions of each eigendirection (columns) to projections
+            associated with every observation (rows). 'proj_kfda' contains the
+            cumulated sum of the values in 'proj_kpca'.
         """
         with warnings.catch_warnings():
             if verbose < 2:
@@ -486,10 +501,19 @@ class Ktest(Statistics):
 
             if self.kfda_statistic is None:
                 self.test(stat='kfda')
-            (self.kfda_proj, self.kfda_proj_contrib) = \
+
+            # compute projections
+            kfda_proj, kfda_proj_contrib = \
                 self.kstat.compute_projections(
-                    self.kfda_statistic, t=t, center=center
+                    self.kfda_statistic, t=t, center=center, new_obs=new_obs
                 )
+
+            # record projections only when projecting training data
+            self.kfda_proj = kfda_proj
+            self.kfda_proj_contrib = kfda_proj_contrib
+
+            # output
+            return kfda_proj, kfda_proj_contrib
 
     def plot_density(
         self, t=None, t_max=100, colors=None, labels=None, alpha=.5,

--- a/python/src/ktest/utils.py
+++ b/python/src/ktest/utils.py
@@ -1,4 +1,5 @@
-from numbers import Number
+from collections.abc import Iterable
+from numbers import Integral, Number
 import warnings
 import numpy as np
 import torch as to
@@ -68,3 +69,78 @@ def pred_threshold_fun(
 
     return (x < 1/2) * (2 * left_val * x - left_val) + \
         (x >= 1/2) * (2 * right_val * x - right_val)
+
+
+def compute_accuracy(
+    prediction: list[np.ndarray], ground_truth: np.ndarray,
+    ref: Integral | str | None = None
+) -> list[np.ndarray]:
+    """
+    Compute accuracy indicator between an array of predictions (observations x
+    truncations) and the vector of ground truth values.
+
+    Note: prediction and ground_truth should have the same encoding for the
+    two classes, i.e. either two value strings or 0-1 integers.
+
+    Input:
+        prediction (list of numpy.ndarray): list of 2-D arrays of class
+            predictions for observations (in rows) and truncation values
+            (in columns), corresponding to different predication bias values.
+        ground_truth (numpy.ndarray): vector (1-D array) of class ground truth
+            values for each observations.
+        ref (numbers.Integral or str or None): class of reference for
+            computing true positive rate. The other class will be used for
+            computing true negative rate. `ref` type should correspond to
+            `prediction` and `ground_truth` array dtype. Default is `None`
+            and first class appearing in `ground_truth` vector is used as
+            reference.
+
+    Output:
+        accuracy (list of numpy.ndarray): list of 2-D arrays of
+            prediction accuracy (`1` for correct, `0` for wrong)
+            for observations (in rows) and increasing truncation values
+            (in columns), corresponding to different predication bias values.
+        true_pos (list of numpy.ndarray): list of 2-D arrays of
+            prediction true positives (`1` for correct, `0` for wrong)
+            for positive only observations (in rows) and increasing truncation
+            values (in columns), corresponding to different predication bias
+            values.s
+        true_neg (list of numpy.ndarray): list of 2-D arrays of
+            prediction true negatives (`1` for correct, `0` for wrong)
+            for negative only observations (in rows) and increasing truncation
+            values (in columns), corresponding to different predication bias
+            values.
+
+    """
+
+    # check reference
+    if ref is None:
+        ref = ground_truth[0]
+
+    # convert input to binary indicator
+    ground_truth_ind = (ground_truth == ref).astype(np.uint8)
+    prediction_ind = [
+        (pred_tab == ref).astype(np.uint8) for pred_tab in prediction
+    ]
+    ref_ind = 1
+
+    # init output
+    accuracy = []
+    true_pos = []
+    true_neg = []
+
+    # loop over prediction arrays
+    for i, pred_tab in enumerate(prediction_ind):
+        # compute accuracy indicator
+        accuracy_tab = 1 - (
+            pred_tab != ground_truth_ind[:, None]
+        ).astype(np.uint8)
+        # store error
+        accuracy.append(accuracy_tab)
+        # compute and store true positive
+        true_pos.append(accuracy_tab[ground_truth_ind == ref_ind])
+        # compute and store true negative
+        true_neg.append(accuracy_tab[ground_truth_ind != ref_ind])
+
+    # output
+    return accuracy, true_pos, true_neg

--- a/python/src/ktest/utils.py
+++ b/python/src/ktest/utils.py
@@ -1,5 +1,7 @@
 from numbers import Number
 import warnings
+import numpy as np
+import torch as to
 
 
 def verbosity(msg: str, msg_type: str = "print", verbose: int | bool = 0):
@@ -33,3 +35,36 @@ def verbosity(msg: str, msg_type: str = "print", verbose: int | bool = 0):
             print(msg)
         elif msg_type == "warning":
             warnings.warn(msg, UserWarning)
+
+
+def pred_threshold_fun(
+    x: float,
+    left_val: float | np.ndarray | to.Tensor,
+    right_val: float | np.ndarray | to.Tensor
+):
+    """
+    Define a piecewise linear function that fit the following points:
+    [0, -left_val], [1/2, 0] and [1, right_val] to compute the prediction
+    bias in kFDA.
+
+    x -> y = 2*left_val*x - left_val if x < 1/2
+         y = 2*right_val*x - right_val if x >= 1/2
+
+    Note: if array-like object, `left_val` and `right_val` should have the
+    same shape.
+
+    Input:
+        x (float): input number between 0 and 1.
+        left_val (float | np.ndarray | t.Tensor): positive number or
+            array of positive numbers corresponding to the y-axis value
+            for x = 0.
+        right_val (float | np.ndarray | t.Tensor): positive number or
+            array of positive numbers corresponding to the y-axis value
+            for x = 1.
+
+    Output: result value or array of result values when the piecewise linear
+        function is applied to input x.
+    """
+
+    return (x < 1/2) * (2 * left_val * x - left_val) + \
+        (x >= 1/2) * (2 * right_val * x - right_val)

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -14,22 +14,38 @@ def data_shape():
 
 
 @pytest.fixture
-def dummy_data(data_shape):
-    """Generate dummy data for testing (two groups, no difference)"""
+def dummy_data_array(data_shape):
+    """
+    Generate dummy data as numpy array for testing
+    (two groups, no difference).
+    """
     # generate random data (under H0, no separation)
     rng = np.random.default_rng(42)
     data_array = rng.normal(loc=0, scale=1, size=data_shape)
 
+    # create meta data frame indicating two groups
+    meta_array = np.array(
+        [f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data_array, meta_array
+
+
+@pytest.fixture
+def dummy_data(dummy_data_array, data_shape):
+    """
+    Generate dummy data as pandas array for testing
+    (two groups, no difference).
+    """
     # create a data frame from random gaussian data
     data = pd.DataFrame(
-        data=data_array,
+        data=dummy_data_array[0],
         columns=[f"col{i+1}" for i in range(data_shape[1])]
     )
 
     # create meta data frame indicating two groups
-    meta = pd.Series(
-        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
-    )
+    meta = pd.Series(data=dummy_data_array[1])
 
     # output
     yield data, meta
@@ -184,32 +200,42 @@ def _check_ktest_data_object(
     assert isinstance(data_obj.data, dict)
 
     # check variable index
-    assert all(data_obj.variables == data_tab.columns)
+    if isinstance(data_obj, pd.DataFrame):
+        assert all(data_obj.variables == data_tab.columns)
 
     # check details about data, index and nobs attributes
-    for subsample in data_obj.sample_names:
+    for i, subsample in enumerate(data_obj.sample_names):
         # expected number of observations in subsample
-        exp_nobs = np.sum(metadata_tab == subsample) if not nystrom else exp_tot_nobs // 2
+        exp_nobs = np.sum(metadata_tab == subsample) if not nystrom \
+            else exp_tot_nobs // 2
 
         # check number of observations in subsample
         assert data_obj.nobs[subsample] == exp_nobs
 
         # check subsample index
-        assert all(
-            data_obj.index[subsample] ==
-            data_tab.iloc[data_obj.index[subsample]].index
-        )
+        if isinstance(data_obj, pd.DataFrame):
+            assert all(
+                data_obj.index[subsample] ==
+                data_tab.iloc[data_obj.index[subsample]].index
+            )
 
         # check subsample data
         assert isinstance(data_obj.data[subsample], t.Tensor)
         assert list(data_obj.data[subsample].shape) == \
             [exp_nobs, data_tab_shape[1]]
-        np.testing.assert_equal(
-            data_obj.data[subsample].numpy(),
-            data_tab.iloc[
-                data_obj.index[subsample]
-            ].to_numpy()
-        )
+
+        if isinstance(data_obj, pd.DataFrame):
+            np.testing.assert_equal(
+                data_obj.data[subsample].numpy(),
+                data_tab.iloc[
+                    data_obj.index[subsample]
+                ].to_numpy()
+            )
+        elif isinstance(data_obj, np.ndarray):
+            np.testing.assert_equal(
+                data_obj.data[subsample].numpy(),
+                data_tab[metadata_tab == subsample]
+            )
 
 
 class TestData:
@@ -367,3 +393,18 @@ class TestData:
                 dtype=t.float64
             )
         assert str(excinfo.value) == err_msg
+
+    def test_init_numpy_array(self, dummy_data_array, data_shape):
+        """Testing Data object instantiation with numpy array."""
+        # init data object
+        base_data = Data(
+            data=dummy_data_array[0],
+            metadata=dummy_data_array[1],
+            sample_names=None,
+            dtype=t.float64
+        )
+        _check_ktest_data_object(
+            base_data, dummy_data_array[0], dummy_data_array[1], data_shape, nystrom=False
+        )
+
+

--- a/python/tests/test_data.py
+++ b/python/tests/test_data.py
@@ -36,6 +36,36 @@ def dummy_data(data_shape):
 
 
 @pytest.fixture
+def dummy_separated_data(data_shape):
+    """Generate dummy data for testing (two groups, significant difference)"""
+    # generate random data with different mean in different the 2 groups
+    # for 10 features, and only noise in other features
+    rng = np.random.default_rng(42)
+    loc = np.hstack([
+        np.tile(
+            np.array([-2, 2])[np.arange(data_shape[0]) % 2][:, np.newaxis],
+            (1, 10)
+        ) + rng.normal(loc=0, scale=1, size=[data_shape[0], 10]),
+        np.zeros([data_shape[0], data_shape[1] - 10], dtype=np.float64)
+    ])
+    data_array = rng.normal(loc=loc, scale=1, size=data_shape)
+
+    # create a data frame from random gaussian data
+    data = pd.DataFrame(
+        data=data_array,
+        columns=[f"col{i+1}" for i in range(data_shape[1])]
+    )
+
+    # create meta data frame indicating two groups
+    meta = pd.Series(
+        data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+    )
+
+    # output
+    yield data, meta
+
+
+@pytest.fixture
 def dummy_zidata(data_shape):
     """
     Generate dummy zero-inflated data for testing (two groups, no difference).
@@ -92,9 +122,40 @@ def ktest_data_nystrom(dummy_data):
     yield ny_data
 
 
+@pytest.fixture
+def ktest_separated_data(dummy_separated_data):
+    """Convert pandas array to ktest `Data` type."""
+    data = Data(
+        data=dummy_separated_data[0],
+        metadata=dummy_separated_data[1],
+        sample_names=None,
+        nystrom=False,
+        dtype=t.float64
+    )
+
+    yield data
+
+
+@pytest.fixture
+def ktest_separated_data_nystrom(dummy_separated_data):
+    """Convert pandas array to ktest `Data` type."""
+    data = Data(
+        data=dummy_separated_data[0],
+        metadata=dummy_separated_data[1],
+        sample_names=None,
+        nystrom=True,
+        n_landmarks=None,
+        landmark_method='random',
+        random_state=None,
+        dtype=t.float64
+    )
+
+    yield data
+
+
 def _check_ktest_data_object(
-        data_obj, data_tab, metadata_tab, data_tab_shape, nystrom=False
-    ):
+    data_obj, data_tab, metadata_tab, data_tab_shape, nystrom=False
+):
     """
     Function to check a ktest data object with or without Nystrom
     approximation.

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -9,7 +9,7 @@ from ktest.kernel_statistics import Statistics
 from ktest.data import Data
 
 from .test_data import (
-    data_shape, dummy_data,
+    data_shape, dummy_data_array, dummy_data,
     ktest_data, ktest_data_nystrom,
     dummy_separated_data,
     ktest_separated_data, ktest_separated_data_nystrom

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-import torch as t
+import torch as to
 import types
 from scipy.linalg import block_diag
 
@@ -12,7 +12,7 @@ from .test_data import data_shape, dummy_data, ktest_data, ktest_data_nystrom
 
 
 def assert_eigenvectors(
-    a: np.ndarray | t.Tensor, b: np.ndarray | t.Tensor,
+    a: np.ndarray | to.Tensor, b: np.ndarray | to.Tensor,
     rtol: float = 0, atol: float = 1e-11
 ):
     """
@@ -25,15 +25,15 @@ def assert_eigenvectors(
 
     # check type
     assert isinstance(a, np.ndarray) and isinstance(b, np.ndarray) or \
-        isinstance(a, t.Tensor) and isinstance(b, t.Tensor)
+        isinstance(a, to.Tensor) and isinstance(b, to.Tensor)
 
     # check dimension
     assert a.shape == b.shape
 
     # setup required functions
-    einsum_fun = np.einsum if isinstance(a, np.ndarray) else t.einsum
+    einsum_fun = np.einsum if isinstance(a, np.ndarray) else to.einsum
 
-    abs_fun = np.abs if isinstance(a, np.ndarray) else t.abs
+    abs_fun = np.abs if isinstance(a, np.ndarray) else to.abs
 
     def assert_eigendecomp(x):
         """Check that a vector is equal to a vector of 1 in absolute value."""
@@ -41,8 +41,8 @@ def assert_eigenvectors(
             np.testing.assert_allclose(
                 x, np.ones(x.shape, dtype=x.dtype), atol=atol, rtol=rtol
             ) if isinstance(a, np.ndarray) else \
-            t.testing.assert_close(
-                x, t.ones(x.shape, dtype=x.dtype), atol=atol, rtol=rtol
+            to.testing.assert_close(
+                x, to.ones(x.shape, dtype=x.dtype), atol=atol, rtol=rtol
             )
 
     # compute column-wise scalar product
@@ -56,13 +56,13 @@ def test_assert_eigenvectors(dummy_data):
     """Test function to compare eigen vectors."""
 
     # get data
-    data_tensor = t.from_numpy(dummy_data[0].values)
+    data_tensor = to.from_numpy(dummy_data[0].values)
 
     # compute a symmetric matrix to decompose
-    sym_matrix = t.matmul(data_tensor, data_tensor.T)
+    sym_matrix = to.matmul(data_tensor, data_tensor.T)
 
     # compute eigen decomposition with torch
-    sp1, ev1 = t.linalg.eigh(sym_matrix)
+    sp1, ev1 = to.linalg.eigh(sym_matrix)
 
     # compute eigen decomposition with numpy
     sp2, ev2 = np.linalg.eigh(sym_matrix.numpy())
@@ -75,7 +75,7 @@ def test_assert_eigenvectors(dummy_data):
     # torch input
     assert_eigenvectors(
         ev1[:, sp1 >= 1e-12],
-        t.from_numpy(ev2[:, sp2 >= 1e-12]),
+        to.from_numpy(ev2[:, sp2 >= 1e-12]),
         rtol=0, atol=1e-11
     )
 
@@ -122,24 +122,24 @@ def kstat_nystrom(ktest_data, ktest_data_nystrom):
     yield kstat
 
 
-class TestStatistics:
+class TestStatistics(object):
     """Implement unit tests for Statistics class."""
 
     def test_ordered_eigsy(self, dummy_data):
         """Test eigen decomposition"""
         # get data
-        data_tensor = t.from_numpy(dummy_data[0].values)
+        data_tensor = to.from_numpy(dummy_data[0].values)
 
         # compute a symmetric matrix to decompose
-        sym_matrix = t.matmul(data_tensor, data_tensor.T)
+        sym_matrix = to.matmul(data_tensor, data_tensor.T)
 
         # compute eigen decomposition (without clipping)
         sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=None, clip=False)
 
         # check output
-        assert isinstance(sp, t.Tensor)
+        assert isinstance(sp, to.Tensor)
         assert list(sp.shape) == [sym_matrix.shape[0]]
-        assert isinstance(ev, t.Tensor)
+        assert isinstance(ev, to.Tensor)
         assert list(ev.shape) == [sym_matrix.shape[0], sym_matrix.shape[0]]
 
         # compute eigen decomposition with numpy to compare
@@ -168,9 +168,9 @@ class TestStatistics:
             sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=None, clip=True)
 
         # check output
-        assert isinstance(sp, t.Tensor)
+        assert isinstance(sp, to.Tensor)
         assert list(sp.shape) < [sym_matrix.shape[0]]
-        assert isinstance(ev, t.Tensor)
+        assert isinstance(ev, to.Tensor)
         assert list(ev.shape) == [sym_matrix.shape[0], sp.shape[0]]
 
         # check eigen values
@@ -191,9 +191,9 @@ class TestStatistics:
             sp, ev = Statistics.ordered_eigsy(sym_matrix, eps=1e-12, clip=True)
 
         # check output
-        assert isinstance(sp, t.Tensor)
+        assert isinstance(sp, to.Tensor)
         assert list(sp.shape) < [sym_matrix.shape[0]]
-        assert isinstance(ev, t.Tensor)
+        assert isinstance(ev, to.Tensor)
         assert list(ev.shape) == [sym_matrix.shape[0], sp.shape[0]]
 
         # check eigen values
@@ -214,7 +214,7 @@ class TestStatistics:
         # no Nystrom
         assert isinstance(kstat.data, Data)
         assert kstat.data_ny is None
-        assert kstat.dtype == t.float64
+        assert kstat.dtype == to.float64
         assert kstat.eps is None or isinstance(kstat.eps, float)
         assert isinstance(kstat.clip_eigval, bool) and kstat.clip_eigval
         assert kstat.n_anchors is None
@@ -227,7 +227,7 @@ class TestStatistics:
         assert isinstance(kstat.kernel, types.FunctionType)
         assert isinstance(kstat.computed_bandwidth, t.Tensor) and \
             len(kstat.computed_bandwidth.shape) == 0 and \
-            kstat.computed_bandwidth.dtype == t.float64
+            kstat.computed_bandwidth.dtype == to.float64
         assert kstat.sp is None
         assert kstat.ev is None
         assert kstat.sp_anchors is None
@@ -236,7 +236,7 @@ class TestStatistics:
         # Nystrom
         assert isinstance(kstat_nystrom.data, Data)
         assert isinstance(kstat_nystrom.data_ny, Data)
-        assert kstat_nystrom.dtype == t.float64
+        assert kstat_nystrom.dtype == to.float64
         assert kstat_nystrom.eps is None or \
             isinstance(kstat_nystrom.eps, float)
         assert isinstance(kstat_nystrom.clip_eigval, bool) and \
@@ -252,9 +252,9 @@ class TestStatistics:
         assert isinstance(kstat_nystrom.median_coef, int) and \
             kstat_nystrom.median_coef == 1
         assert isinstance(kstat_nystrom.kernel, types.FunctionType)
-        assert isinstance(kstat_nystrom.computed_bandwidth, t.Tensor) and \
+        assert isinstance(kstat_nystrom.computed_bandwidth, to.Tensor) and \
             len(kstat_nystrom.computed_bandwidth.shape) == 0 and \
-            kstat_nystrom.computed_bandwidth.dtype == t.float64
+            kstat_nystrom.computed_bandwidth.dtype == to.float64
         assert kstat_nystrom.sp is None
         assert kstat_nystrom.ev is None
         assert kstat_nystrom.sp_anchors is None
@@ -278,7 +278,7 @@ class TestStatistics:
             n_landmarks=None,
             landmark_method='random',
             random_state=None,
-            dtype=t.float64
+            dtype=to.float64
         )
 
         # init data object without nystrom
@@ -286,7 +286,7 @@ class TestStatistics:
             data=data,
             metadata=metadata,
             sample_names=None,
-            dtype=t.float64
+            dtype=to.float64
         )
 
         # kernel stat object
@@ -329,7 +329,7 @@ class TestStatistics:
 
         # no Nystrom
         res = kstat.compute_centering_matrix(landmarks=False)
-        assert isinstance(res, t.Tensor)
+        assert isinstance(res, to.Tensor)
         assert len(res.shape) == 2
 
         exp_dim = kstat.data.ntot
@@ -346,7 +346,7 @@ class TestStatistics:
 
         # Nystrom: anchor_basis == 'w' (default mode)
         res = kstat_nystrom.compute_centering_matrix(landmarks=True)
-        assert isinstance(res, t.Tensor)
+        assert isinstance(res, to.Tensor)
         assert len(res.shape) == 2
 
         exp_dim = kstat_nystrom.data_ny.ntot
@@ -359,7 +359,7 @@ class TestStatistics:
         # Nystrom: anchor_basis == 'k'
         kstat_nystrom.anchor_basis = 'k'
         res = kstat_nystrom.compute_centering_matrix(landmarks=True)
-        assert isinstance(res, t.Tensor)
+        assert isinstance(res, to.Tensor)
         assert len(res.shape) == 2
 
         exp_dim = kstat_nystrom.data_ny.ntot
@@ -372,7 +372,7 @@ class TestStatistics:
         # Nystrom: anchor_basis == 's'
         kstat_nystrom.anchor_basis = 's'
         res = kstat_nystrom.compute_centering_matrix(landmarks=True)
-        assert isinstance(res, t.Tensor)
+        assert isinstance(res, to.Tensor)
         assert len(res.shape) == 2
 
         exp_dim = kstat_nystrom.data_ny.ntot
@@ -383,17 +383,18 @@ class TestStatistics:
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
     def test_compute_gram(self, kstat, kstat_nystrom, data_shape):
+        """Testing Gram matrix computation."""
         # Case 1 - full data, no landmarks, no new_obs
         # default: landmarks=False, new_obs=None
         K = kstat.compute_gram()
 
         # Expected Gram matrix using the same gaussian kernel
-        D = t.cat(tuple(kstat.data.data.values()), dim=0)
+        D = to.cat(tuple(kstat.data.data.values()), dim=0)
         expected = kstat.kernel(D, D)
 
-        assert isinstance(K, t.Tensor)
+        assert isinstance(K, to.Tensor)
         assert K.shape == (data_shape[0], data_shape[0])
-        t.testing.assert_close(K, expected)
+        to.testing.assert_close(K, expected)
 
         # Case 2 - compute K(D, new_obs)
         # new observations: use one population subsample
@@ -402,23 +403,23 @@ class TestStatistics:
         K = kstat.compute_gram(new_obs=new_obs)
 
         # Expected Gram matrix using the same gaussian kernel
-        D = t.cat(tuple(kstat.data.data.values()), dim=0)
+        D = to.cat(tuple(kstat.data.data.values()), dim=0)
         expected = kstat.kernel(D, new_obs)
 
-        assert isinstance(K, t.Tensor)
+        assert isinstance(K, to.Tensor)
         assert K.shape == (data_shape[0], new_obs.shape[0])
-        t.testing.assert_close(K, expected)
+        to.testing.assert_close(K, expected)
 
         # Case 3 - landmarks=True and a Nyström dataset is provided
         K = kstat_nystrom.compute_gram(landmarks=True)
 
         # Expected Gram matrix using the same gaussian kernel
-        D = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = to.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
         expected = kstat_nystrom.kernel(D, D)
 
-        assert isinstance(K, t.Tensor)
+        assert isinstance(K, to.Tensor)
         assert K.shape == (data_shape[0]//5, data_shape[0]//5)
-        t.testing.assert_close(K, expected)
+        to.testing.assert_close(K, expected)
 
         # Case 4 - landmarks=True but a Nyström dataset is not provided
         with pytest.raises(ValueError, match="Cannot use landmarks"):
@@ -431,14 +432,15 @@ class TestStatistics:
         K = kstat_nystrom.compute_gram(landmarks=True, new_obs=new_obs)
 
         # Expected Gram matrix using the same gaussian kernel
-        D = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = to.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
         expected = kstat_nystrom.kernel(D, new_obs)
 
-        assert isinstance(K, t.Tensor)
+        assert isinstance(K, to.Tensor)
         assert K.shape == (data_shape[0]//5, new_obs.shape[0])
-        t.testing.assert_close(K, expected)
+        to.testing.assert_close(K, expected)
 
     def test_compute_kmn(self, kstat, kstat_nystrom, data_shape):
+        """Testing Gram matrix computation between landmarks and data."""
         # Case 0 - not using Nystrom
         with pytest.raises(
             AttributeError, match="'NoneType' object has no attribute 'data'"
@@ -450,14 +452,13 @@ class TestStatistics:
         Kmn = kstat_nystrom.compute_kmn()
 
         # Expected Gram matrix using the same gaussian kernel
-        landmarks = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
-        D = t.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
+        landmarks = to.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = to.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
         expected = kstat_nystrom.kernel(landmarks, D)
 
-        assert isinstance(Kmn, t.Tensor)
+        assert isinstance(Kmn, to.Tensor)
         assert Kmn.shape == (landmarks.shape[0], data_shape[0])
-        t.testing.assert_close(Kmn, expected)
-
+        to.testing.assert_close(Kmn, expected)
 
         # Case 2 - compute K(landmarks, new_obs)
         # new observations: use one population subsample
@@ -466,13 +467,13 @@ class TestStatistics:
         Kmn = kstat_nystrom.compute_kmn(new_obs=new_obs)
 
         # Expected Gram matrix using the same gaussian kernel
-        landmarks = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
-        D = t.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
+        landmarks = to.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = to.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
         expected = kstat_nystrom.kernel(landmarks, new_obs)
 
-        assert isinstance(Kmn, t.Tensor)
+        assert isinstance(Kmn, to.Tensor)
         assert Kmn.shape == (landmarks.shape[0], new_obs.shape[0])
-        t.testing.assert_close(Kmn, expected)
+        to.testing.assert_close(Kmn, expected)
 
     def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """
@@ -484,10 +485,10 @@ class TestStatistics:
         res1 = kstat.compute_centered_gram(low_mem_footprint=False)
         res2 = kstat.compute_centered_gram(low_mem_footprint=True)
 
-        assert isinstance(res1, t.Tensor)
+        assert isinstance(res1, to.Tensor)
         assert list(res1.shape) == [data_shape[0], data_shape[0]]
 
-        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+        to.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
 
         # Nystrom: anchor_basis == 'w' (default mode)
         res1 = kstat_nystrom.compute_centered_gram(low_mem_footprint=False)
@@ -495,12 +496,12 @@ class TestStatistics:
 
         exp_dim = kstat_nystrom.sp_anchors.shape[0]
 
-        assert isinstance(res1, t.Tensor)
+        assert isinstance(res1, to.Tensor)
         assert list(res1.shape) == [exp_dim, exp_dim]
-        assert isinstance(res2, t.Tensor)
+        assert isinstance(res2, to.Tensor)
         assert list(res2.shape) == [exp_dim, exp_dim]
 
-        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+        to.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
 
         # Nystrom: anchor_basis == 'k'
         kstat_nystrom.anchor_basis = 'k'
@@ -509,12 +510,12 @@ class TestStatistics:
 
         exp_dim = kstat_nystrom.sp_anchors.shape[0]
 
-        assert isinstance(res1, t.Tensor)
+        assert isinstance(res1, to.Tensor)
         assert list(res1.shape) == [exp_dim, exp_dim]
-        assert isinstance(res2, t.Tensor)
+        assert isinstance(res2, to.Tensor)
         assert list(res2.shape) == [exp_dim, exp_dim]
 
-        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+        to.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
 
         # Nystrom: anchor_basis == 's'
         kstat_nystrom.anchor_basis = 's'
@@ -523,32 +524,33 @@ class TestStatistics:
 
         exp_dim = kstat_nystrom.sp_anchors.shape[0]
 
-        assert isinstance(res1, t.Tensor)
+        assert isinstance(res1, to.Tensor)
         assert list(res1.shape) == [exp_dim, exp_dim]
-        assert isinstance(res2, t.Tensor)
+        assert isinstance(res2, to.Tensor)
         assert list(res2.shape) == [exp_dim, exp_dim]
 
-        t.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
+        to.testing.assert_close(res1, res2, rtol=0, atol=1e-12)
 
     def test_diagonalize_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """
         Testing centered Gram matrix diagonalization,
         with or without the computing trick to avoid storing the full
-        n x n centering matrix."""
+        n x n centering matrix.
+        """
 
         # no Nystrom: no effect of 'low_mem_footprint' option
         sp1, ev1 = kstat.diagonalize_centered_gram(low_mem_footprint=False)
         sp2, ev2 = kstat.diagonalize_centered_gram(low_mem_footprint=True)
 
         # check output
-        assert isinstance(sp1, t.Tensor)
+        assert isinstance(sp1, to.Tensor)
         assert list(sp1.shape) == [data_shape[0] - 2]
-        assert isinstance(ev1, t.Tensor)
+        assert isinstance(ev1, to.Tensor)
         assert list(ev1.shape) == [data_shape[0], data_shape[0] - 2]
         # note: last 2 eigen values are clipped
 
-        t.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
-        t.testing.assert_close(ev1, ev2, rtol=0, atol=1e-12)
+        to.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
+        to.testing.assert_close(ev1, ev2, rtol=0, atol=1e-12)
 
         # compute eigen decomposition with numpy to compare
         # /!\ eigen values/vectors are in reverse order
@@ -581,14 +583,14 @@ class TestStatistics:
         )
 
         # check output
-        assert isinstance(sp1, t.Tensor)
+        assert isinstance(sp1, to.Tensor)
         assert list(sp1.shape) == [data_shape[0] // 5 - 2]
-        assert isinstance(ev1, t.Tensor)
+        assert isinstance(ev1, to.Tensor)
         assert list(ev1.shape) == \
             [data_shape[0] // 5 - 2, data_shape[0] // 5 - 2]
         # note: last 2 eigen values are clipped
 
-        t.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
+        to.testing.assert_close(sp1, sp2, rtol=0, atol=1e-12)
         assert_eigenvectors(ev1, ev2, rtol=0, atol=1e-12)
 
         # compute eigen decomposition with numpy to compare
@@ -614,13 +616,14 @@ class TestStatistics:
         )
 
     def test_compute_upk(self, kstat, kstat_nystrom, data_shape):
+        """Testing uPK product computation."""
         # FIXME: only result format is tested, not result values
 
         # Case 1 - full data (no Nystrom), no new_obs
         # default: new_obs=None
         upk = kstat.compute_upk(t=10)
 
-        assert isinstance(upk, t.Tensor)
+        assert isinstance(upk, to.Tensor)
         assert upk.shape == (data_shape[0], 10)
 
         # Case 2 - providing new obs
@@ -629,14 +632,14 @@ class TestStatistics:
 
         upk = kstat.compute_upk(t=10, new_obs=new_obs)
 
-        assert isinstance(upk, t.Tensor)
+        assert isinstance(upk, to.Tensor)
         assert upk.shape == (new_obs.shape[0], 10)
 
         # Case 3 - Nystrom, no new_obs
         # default: new_obs=None
         upk = kstat_nystrom.compute_upk(t=10)
 
-        assert isinstance(upk, t.Tensor)
+        assert isinstance(upk, to.Tensor)
         assert upk.shape == (data_shape[0], 10)
 
         # Case 4 - Nystrom, providing new obs
@@ -645,10 +648,11 @@ class TestStatistics:
 
         upk = kstat_nystrom.compute_upk(t=10, new_obs=new_obs)
 
-        assert isinstance(upk, t.Tensor)
+        assert isinstance(upk, to.Tensor)
         assert upk.shape == (new_obs.shape[0], 10)
 
     def test_compute_projections(self, kstat, kstat_nystrom):
+        """Testing kFDA axis projection computation."""
         # FIXME: only result format is tested, not result values
 
         def _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val):

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -757,9 +757,31 @@ class TestStatistics(object):
     ):
         """Testing kFDA prediction computation."""
 
-        # Case 1 - full data (no Nystrom), no new_obs
+        # Case 1a - full data (no Nystrom), no new_obs
         # default: new_obs=None
         dist_g1, dist_g2 = kstat.kfda_loss(t=10)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert dist_g1.keys() == kstat.data.data.keys()
+        assert dist_g2.keys() == kstat.data.data.keys()
+
+        for group in kstat.data.data.keys():
+            n_obs = kstat.data.data[group].shape[0]
+
+            assert isinstance(dist_g1[group], to.Tensor)
+            assert isinstance(dist_g2[group], to.Tensor)
+
+            assert list(dist_g1[group].shape) == [n_obs, 10]
+            assert list(dist_g2[group].shape) == [n_obs, 10]
+
+            assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+            assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+        # Case 1b - full data (no Nystrom), no new_obs, providing stat value
+        # default: new_obs=None
+        stat_val, _ = kstat.compute_kfda()
+        dist_g1, dist_g2 = kstat.kfda_loss(t=10, stat=stat_val)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -437,6 +437,42 @@ class TestStatistics:
         assert K.shape == (data_shape[0]//5, new_obs.shape[0])
         t.testing.assert_close(K, expected)
 
+    def test_compute_kmn(self, kstat, kstat_nystrom, data_shape):
+        # Case 0 – not using Nystrom
+        with pytest.raises(
+            AttributeError, match="'NoneType' object has no attribute 'data'"
+        ):
+            Kmn = kstat.compute_kmn()
+
+        # Case 1 – full data, no new_obs
+        # default: new_obs=None
+        Kmn = kstat_nystrom.compute_kmn()
+
+        # Expected Gram matrix using the same gaussian kernel
+        landmarks = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = t.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
+        expected = kstat_nystrom.kernel(landmarks, D)
+
+        assert isinstance(Kmn, t.Tensor)
+        assert Kmn.shape == (landmarks.shape[0], data_shape[0])
+        t.testing.assert_close(Kmn, expected)
+
+
+        # Case 2 – compute K(landmarks, new_obs)
+        # New observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+
+        Kmn = kstat_nystrom.compute_kmn(new_obs=new_obs)
+
+        # Expected Gram matrix using the same gaussian kernel
+        landmarks = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        D = t.cat(tuple(kstat_nystrom.data.data.values()), dim=0)
+        expected = kstat_nystrom.kernel(landmarks, new_obs)
+
+        assert isinstance(Kmn, t.Tensor)
+        assert Kmn.shape == (landmarks.shape[0], new_obs.shape[0])
+        t.testing.assert_close(Kmn, expected)
+
     def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """
         Testing centered Gram matrix computation,

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -8,7 +8,12 @@ from scipy.linalg import block_diag
 from ktest.kernel_statistics import Statistics
 from ktest.data import Data
 
-from .test_data import data_shape, dummy_data, ktest_data, ktest_data_nystrom
+from .test_data import (
+    data_shape, dummy_data,
+    ktest_data, ktest_data_nystrom,
+    dummy_separated_data,
+    ktest_separated_data, ktest_separated_data_nystrom
+)
 
 
 def assert_eigenvectors(
@@ -746,3 +751,388 @@ class TestStatistics(object):
         n_obs_val = [new_obs.shape[0]]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
 
+    def test_kfda_loss(
+        self, kstat, kstat_nystrom, ktest_separated_data,
+        ktest_separated_data_nystrom
+    ):
+        """Testing kFDA prediction computation."""
+
+        # Case 1 - full data (no Nystrom), no new_obs
+        # default: new_obs=None
+        dist_g1, dist_g2 = kstat.kfda_loss(t=10)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert dist_g1.keys() == kstat.data.data.keys()
+        assert dist_g2.keys() == kstat.data.data.keys()
+
+        for group in kstat.data.data.keys():
+            n_obs = kstat.data.data[group].shape[0]
+
+            assert isinstance(dist_g1[group], to.Tensor)
+            assert isinstance(dist_g2[group], to.Tensor)
+
+            assert list(dist_g1[group].shape) == [n_obs, 10]
+            assert list(dist_g2[group].shape) == [n_obs, 10]
+
+            assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+            assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+        # Case 2 - full data (no Nystrom), providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+        dist_g1, dist_g2 = kstat.kfda_loss(t=10, new_obs=new_obs)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert list(dist_g1.keys()) == ["new_obs"]
+        assert list(dist_g2.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(dist_g1[group], to.Tensor)
+        assert isinstance(dist_g2[group], to.Tensor)
+
+        assert list(dist_g1[group].shape) == [n_obs, 10]
+        assert list(dist_g2[group].shape) == [n_obs, 10]
+
+        assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+        assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+        # Case 3 - Nystrom approximation, no new_obs
+        # default: new_obs=None
+        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(t=10)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert dist_g1.keys() == kstat_nystrom.data.data.keys()
+        assert dist_g2.keys() == kstat_nystrom.data.data.keys()
+
+        for group in kstat_nystrom.data.data.keys():
+            n_obs = kstat_nystrom.data.data[group].shape[0]
+
+            assert isinstance(dist_g1[group], to.Tensor)
+            assert isinstance(dist_g2[group], to.Tensor)
+
+            assert list(dist_g1[group].shape) == [n_obs, 10]
+            assert list(dist_g2[group].shape) == [n_obs, 10]
+
+            assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+            assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+        # Case 4 - Nystrom approximation, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(t=10, new_obs=new_obs)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert list(dist_g1.keys()) == ["new_obs"]
+        assert list(dist_g2.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(dist_g1[group], to.Tensor)
+        assert isinstance(dist_g2[group], to.Tensor)
+
+        assert list(dist_g1[group].shape) == [n_obs, 10]
+        assert list(dist_g2[group].shape) == [n_obs, 10]
+
+        assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+        assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+        # Case 5 - separated data (Nystrom approximation, no new_obs)
+        # kernel stat object
+        kstat_sep = Statistics(
+            data=ktest_separated_data,
+            kernel_function='gauss',
+            bandwidth='median',
+            median_coef=1,
+            data_nystrom=ktest_separated_data_nystrom,
+            n_anchors=None,
+            anchor_basis='w',
+            eps=None, clip_eigval=True
+        )
+
+        dist_g1, dist_g2 = kstat_sep.kfda_loss(t=10)
+
+        assert isinstance(dist_g1, dict)
+        assert isinstance(dist_g2, dict)
+        assert dist_g1.keys() == kstat_sep.data.data.keys()
+        assert dist_g2.keys() == kstat_sep.data.data.keys()
+
+        for group in kstat_nystrom.data.data.keys():
+            n_obs = kstat_sep.data.data[group].shape[0]
+
+            assert isinstance(dist_g1[group], to.Tensor)
+            assert isinstance(dist_g2[group], to.Tensor)
+
+            assert list(dist_g1[group].shape) == [n_obs, 10]
+            assert list(dist_g2[group].shape) == [n_obs, 10]
+
+            assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
+            assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
+
+    def test_kfda_predict(
+        self, kstat, kstat_nystrom, ktest_separated_data,
+        ktest_separated_data_nystrom
+    ):
+        """Testing kFDA prediction computation."""
+
+        # Case 1a - full data (no Nystrom), no new_obs
+        # default: new_obs=None
+        pred, loss = kstat.kfda_predict(t=10, pred_threshold=1/2)
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert pred.keys() == kstat.data.data.keys()
+        assert loss.keys() == kstat.data.data.keys()
+
+        for group in kstat.data.data.keys():
+            n_obs = kstat.data.data[group].shape[0]
+
+            assert isinstance(pred[group], np.ndarray)
+            assert isinstance(loss[group], np.ndarray)
+
+            assert list(pred[group].shape) == [n_obs, 10]
+            assert list(loss[group].shape) == [n_obs, 10]
+
+            assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
+            assert np.issubdtype(loss[group].dtype, np.floating)
+
+            # group 1 and 2 are similar so we expect 50%-50% prediction
+            count_pred = np.count_nonzero(pred[group] == group, axis=0)
+            np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+        # Case 1b - full data (no Nystrom), no new_obs,
+        # with a list of threshold values
+        # default: new_obs=None
+        pred, loss = kstat.kfda_predict(
+            t=10, pred_threshold=np.linspace(0, 1, 11)
+        )
+
+        assert isinstance(pred, list)
+        assert isinstance(loss, list)
+
+        for pred_item, loss_item, pred_threshold in zip(
+            pred, loss, np.linspace(0, 1, 11)
+        ):
+
+            assert isinstance(pred_item, dict)
+            assert isinstance(loss_item, dict)
+            assert pred_item.keys() == kstat.data.data.keys()
+            assert loss_item.keys() == kstat.data.data.keys()
+
+            for group_ind, group in enumerate(kstat.data.data.keys()):
+                n_obs = kstat.data.data[group].shape[0]
+
+                assert isinstance(pred_item[group], np.ndarray)
+                assert isinstance(loss_item[group], np.ndarray)
+
+                assert list(pred_item[group].shape) == [n_obs, 10]
+                assert list(loss_item[group].shape) == [n_obs, 10]
+
+                assert np.all(np.isin(
+                    pred_item[group], list(kstat.data.data.keys())
+                ))
+                assert np.issubdtype(loss_item[group].dtype, np.floating)
+
+                # group 1 and 2 are similar so we expect a prediction
+                # corresponding to the bias
+                # (or 1 - bias depending on the group)
+                count_pred = np.count_nonzero(
+                    pred_item[group] == group, axis=0
+                )
+                np.testing.assert_allclose(
+                    count_pred / n_obs,
+                    (1 - group_ind) * pred_threshold +
+                    group_ind * (1 - pred_threshold),
+                    atol=0.3
+                )
+
+        # Case 2a - full data (no Nystrom), providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+        pred, loss = kstat.kfda_predict(
+            t=10, new_obs=new_obs, pred_threshold=1/2
+        )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert list(pred.keys()) == ["new_obs"]
+        assert list(loss.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(pred[group], np.ndarray)
+        assert isinstance(loss[group], np.ndarray)
+
+        assert list(pred[group].shape) == [n_obs, 10]
+        assert list(loss[group].shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
+        assert np.issubdtype(loss[group].dtype, np.floating)
+
+        # group 1 and 2 are similar so we expect 50%-50% prediction
+        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+        # Case 2b - full data (no Nystrom), providing new_obs,
+        # biasing prediction (expect only group 2 prediction)
+        # new observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+        pred, loss = kstat.kfda_predict(
+            t=10, new_obs=new_obs, pred_threshold=0
+        )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert list(pred.keys()) == ["new_obs"]
+        assert list(loss.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(pred[group], np.ndarray)
+        assert isinstance(loss[group], np.ndarray)
+
+        assert list(pred[group].shape) == [n_obs, 10]
+        assert list(loss[group].shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
+        assert np.issubdtype(loss[group].dtype, np.floating)
+
+        # we expect only "group 2" prediction
+        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 0, atol=0)
+
+        # Case 2c - full data (no Nystrom), providing new_obs,
+        # biasing prediction (expect only group 1 prediction)
+        # new observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+        pred, loss = kstat.kfda_predict(
+            t=10, new_obs=new_obs, pred_threshold=1
+        )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert list(pred.keys()) == ["new_obs"]
+        assert list(loss.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(pred[group], np.ndarray)
+        assert isinstance(loss[group], np.ndarray)
+
+        assert list(pred[group].shape) == [n_obs, 10]
+        assert list(loss[group].shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
+        assert np.issubdtype(loss[group].dtype, np.floating)
+
+        # we expect only "group 1" prediction
+        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1, atol=0)
+
+        # Case 3 - Nystrom approximation, no new_obs
+        # default: new_obs=None
+        pred, loss = kstat_nystrom.kfda_predict(t=10, pred_threshold=1/2)
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert pred.keys() == kstat_nystrom.data.data.keys()
+        assert loss.keys() == kstat_nystrom.data.data.keys()
+
+        for group in kstat_nystrom.data.data.keys():
+            n_obs = kstat_nystrom.data.data[group].shape[0]
+
+            assert isinstance(pred[group], np.ndarray)
+            assert isinstance(loss[group], np.ndarray)
+
+            assert list(pred[group].shape) == [n_obs, 10]
+            assert list(loss[group].shape) == [n_obs, 10]
+
+            assert np.all(
+                np.isin(pred[group], list(kstat_nystrom.data.data.keys()))
+            )
+            assert np.issubdtype(loss[group].dtype, np.floating)
+
+            # group 1 and 2 are similar so we expect 50%-50% prediction
+            count_pred = np.count_nonzero(pred[group] == group, axis=0)
+            np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+        # Case 4 - Nystrom approximation, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+        pred, loss = kstat_nystrom.kfda_predict(
+            t=10, new_obs=new_obs, pred_threshold=1/2
+        )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert list(pred.keys()) == ["new_obs"]
+        assert list(loss.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(pred[group], np.ndarray)
+        assert isinstance(loss[group], np.ndarray)
+
+        assert list(pred[group].shape) == [n_obs, 10]
+        assert list(loss[group].shape) == [n_obs, 10]
+
+        assert np.all(
+            np.isin(pred[group], list(kstat_nystrom.data.data.keys()))
+        )
+        assert np.issubdtype(loss[group].dtype, np.floating)
+
+        # group 1 and 2 are similar so we expect 50%-50% prediction
+        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+        # Case 5 - separated data (Nystrom approximation, no new_obs)
+        # kernel stat object
+        kstat_sep = Statistics(
+            data=ktest_separated_data,
+            kernel_function='gauss',
+            bandwidth='median',
+            median_coef=1,
+            data_nystrom=ktest_separated_data_nystrom,
+            n_anchors=None,
+            anchor_basis='w',
+            eps=None, clip_eigval=True
+        )
+
+        # no bias in prediction, no new observations
+        pred, loss = kstat_sep.kfda_predict(t=50, pred_threshold=1/2)
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert pred.keys() == kstat_sep.data.data.keys()
+        assert loss.keys() == kstat_sep.data.data.keys()
+
+        for i, group in enumerate(kstat_sep.data.data.keys()):
+            n_obs = kstat_sep.data.data[group].shape[0]
+
+            assert isinstance(pred[group], np.ndarray)
+            assert isinstance(loss[group], np.ndarray)
+
+            assert list(pred[group].shape) == [n_obs, 50]
+            assert list(loss[group].shape) == [n_obs, 50]
+
+            assert np.all(
+                np.isin(pred[group], list(kstat_sep.data.data.keys()))
+            )
+            assert np.issubdtype(loss[group].dtype, np.floating)
+
+            # group 1 and 2 are very different so we expect 100%
+            # prediction on each group (at least for large truncations)
+            count_pred = np.count_nonzero(
+                pred[group][:, -10:] == group, axis=0
+            )
+            np.testing.assert_allclose(count_pred / n_obs, 1, atol=0.1)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -915,58 +915,67 @@ class TestStatistics(object):
         for group in kstat.data.data.keys():
             n_obs = kstat.data.data[group].shape[0]
 
-            assert isinstance(pred[group], np.ndarray)
-            assert isinstance(loss[group], np.ndarray)
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
 
-            assert list(pred[group].shape) == [n_obs, 10]
-            assert list(loss[group].shape) == [n_obs, 10]
+            assert len(pred[group]) == 1
+            assert len(loss[group]) == 1
 
-            assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
-            assert np.issubdtype(loss[group].dtype, np.floating)
+            pred_val = pred[group][0]
+            loss_val = loss[group][0]
+
+            assert isinstance(pred_val, np.ndarray)
+            assert isinstance(loss_val, np.ndarray)
+
+            assert list(pred_val.shape) == [n_obs, 10]
+            assert list(loss_val.shape) == [n_obs, 10]
+
+            assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+            assert np.issubdtype(loss_val.dtype, np.floating)
 
             # group 1 and 2 are similar so we expect 50%-50% prediction
-            count_pred = np.count_nonzero(pred[group] == group, axis=0)
+            count_pred = np.count_nonzero(pred_val == group, axis=0)
             np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
 
         # Case 1b - full data (no Nystrom), no new_obs,
         # with a list of threshold values
         # default: new_obs=None
+        threshold_values = np.linspace(0, 1, 11)
         pred, loss = kstat.kfda_predict(
-            t=10, pred_threshold=np.linspace(0, 1, 11)
+            t=10, pred_threshold=threshold_values
         )
 
-        assert isinstance(pred, list)
-        assert isinstance(loss, list)
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert pred.keys() == kstat.data.data.keys()
+        assert loss.keys() == kstat.data.data.keys()
 
-        for pred_item, loss_item, pred_threshold in zip(
-            pred, loss, np.linspace(0, 1, 11)
-        ):
+        for group_ind, group in enumerate(kstat.data.data.keys()):
+            n_obs = kstat.data.data[group].shape[0]
 
-            assert isinstance(pred_item, dict)
-            assert isinstance(loss_item, dict)
-            assert pred_item.keys() == kstat.data.data.keys()
-            assert loss_item.keys() == kstat.data.data.keys()
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
 
-            for group_ind, group in enumerate(kstat.data.data.keys()):
-                n_obs = kstat.data.data[group].shape[0]
+            assert len(pred[group]) == len(threshold_values)
+            assert len(loss[group]) == len(threshold_values)
 
-                assert isinstance(pred_item[group], np.ndarray)
-                assert isinstance(loss_item[group], np.ndarray)
+            for pred_val, loss_val, pred_threshold in zip(
+                pred[group], loss[group], threshold_values
+            ):
 
-                assert list(pred_item[group].shape) == [n_obs, 10]
-                assert list(loss_item[group].shape) == [n_obs, 10]
+                assert isinstance(pred_val, np.ndarray)
+                assert isinstance(loss_val, np.ndarray)
 
-                assert np.all(np.isin(
-                    pred_item[group], list(kstat.data.data.keys())
-                ))
-                assert np.issubdtype(loss_item[group].dtype, np.floating)
+                assert list(pred_val.shape) == [n_obs, 10]
+                assert list(loss_val.shape) == [n_obs, 10]
+
+                assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+                assert np.issubdtype(loss_val.dtype, np.floating)
 
                 # group 1 and 2 are similar so we expect a prediction
                 # corresponding to the bias
                 # (or 1 - bias depending on the group)
-                count_pred = np.count_nonzero(
-                    pred_item[group] == group, axis=0
-                )
+                count_pred = np.count_nonzero(pred_val == group, axis=0)
                 np.testing.assert_allclose(
                     count_pred / n_obs,
                     (1 - group_ind) * pred_threshold +
@@ -989,17 +998,26 @@ class TestStatistics(object):
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
-        assert isinstance(pred[group], np.ndarray)
-        assert isinstance(loss[group], np.ndarray)
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
 
-        assert list(pred[group].shape) == [n_obs, 10]
-        assert list(loss[group].shape) == [n_obs, 10]
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
 
-        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
-        assert np.issubdtype(loss[group].dtype, np.floating)
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
-        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        count_pred = np.count_nonzero(pred_val == "c1", axis=0)
         np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
 
         # Case 2b - full data (no Nystrom), providing new_obs,
@@ -1018,17 +1036,26 @@ class TestStatistics(object):
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
-        assert isinstance(pred[group], np.ndarray)
-        assert isinstance(loss[group], np.ndarray)
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
 
-        assert list(pred[group].shape) == [n_obs, 10]
-        assert list(loss[group].shape) == [n_obs, 10]
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
 
-        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
-        assert np.issubdtype(loss[group].dtype, np.floating)
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
 
         # we expect only "group 2" prediction
-        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        count_pred = np.count_nonzero(pred_val == "c1", axis=0)
         np.testing.assert_allclose(count_pred / n_obs, 0, atol=0)
 
         # Case 2c - full data (no Nystrom), providing new_obs,
@@ -1047,17 +1074,26 @@ class TestStatistics(object):
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
-        assert isinstance(pred[group], np.ndarray)
-        assert isinstance(loss[group], np.ndarray)
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
 
-        assert list(pred[group].shape) == [n_obs, 10]
-        assert list(loss[group].shape) == [n_obs, 10]
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
 
-        assert np.all(np.isin(pred[group], list(kstat.data.data.keys())))
-        assert np.issubdtype(loss[group].dtype, np.floating)
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
 
         # we expect only "group 1" prediction
-        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        count_pred = np.count_nonzero(pred_val == "c1", axis=0)
         np.testing.assert_allclose(count_pred / n_obs, 1, atol=0)
 
         # Case 3 - Nystrom approximation, no new_obs
@@ -1069,22 +1105,31 @@ class TestStatistics(object):
         assert pred.keys() == kstat_nystrom.data.data.keys()
         assert loss.keys() == kstat_nystrom.data.data.keys()
 
-        for group in kstat_nystrom.data.data.keys():
+        for group in kstat.data.data.keys():
             n_obs = kstat_nystrom.data.data[group].shape[0]
 
-            assert isinstance(pred[group], np.ndarray)
-            assert isinstance(loss[group], np.ndarray)
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
 
-            assert list(pred[group].shape) == [n_obs, 10]
-            assert list(loss[group].shape) == [n_obs, 10]
+            assert len(pred[group]) == 1
+            assert len(loss[group]) == 1
 
-            assert np.all(
-                np.isin(pred[group], list(kstat_nystrom.data.data.keys()))
-            )
-            assert np.issubdtype(loss[group].dtype, np.floating)
+            pred_val = pred[group][0]
+            loss_val = loss[group][0]
+
+            assert isinstance(pred_val, np.ndarray)
+            assert isinstance(loss_val, np.ndarray)
+
+            assert list(pred_val.shape) == [n_obs, 10]
+            assert list(loss_val.shape) == [n_obs, 10]
+
+            assert np.all(np.isin(
+                pred_val, list(kstat_nystrom.data.data.keys())
+            ))
+            assert np.issubdtype(loss_val.dtype, np.floating)
 
             # group 1 and 2 are similar so we expect 50%-50% prediction
-            count_pred = np.count_nonzero(pred[group] == group, axis=0)
+            count_pred = np.count_nonzero(pred_val == group, axis=0)
             np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
 
         # Case 4 - Nystrom approximation, providing new_obs
@@ -1102,19 +1147,26 @@ class TestStatistics(object):
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
-        assert isinstance(pred[group], np.ndarray)
-        assert isinstance(loss[group], np.ndarray)
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
 
-        assert list(pred[group].shape) == [n_obs, 10]
-        assert list(loss[group].shape) == [n_obs, 10]
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
 
-        assert np.all(
-            np.isin(pred[group], list(kstat_nystrom.data.data.keys()))
-        )
-        assert np.issubdtype(loss[group].dtype, np.floating)
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
-        count_pred = np.count_nonzero(pred[group] == "c1", axis=0)
+        count_pred = np.count_nonzero(pred_val == "c1", axis=0)
         np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
 
         # Case 5 - separated data (Nystrom approximation, no new_obs)
@@ -1141,20 +1193,29 @@ class TestStatistics(object):
         for i, group in enumerate(kstat_sep.data.data.keys()):
             n_obs = kstat_sep.data.data[group].shape[0]
 
-            assert isinstance(pred[group], np.ndarray)
-            assert isinstance(loss[group], np.ndarray)
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
 
-            assert list(pred[group].shape) == [n_obs, 50]
-            assert list(loss[group].shape) == [n_obs, 50]
+            assert len(pred[group]) == 1
+            assert len(loss[group]) == 1
 
-            assert np.all(
-                np.isin(pred[group], list(kstat_sep.data.data.keys()))
-            )
-            assert np.issubdtype(loss[group].dtype, np.floating)
+            pred_val = pred[group][0]
+            loss_val = loss[group][0]
+
+            assert isinstance(pred_val, np.ndarray)
+            assert isinstance(loss_val, np.ndarray)
+
+            assert list(pred_val.shape) == [n_obs, 50]
+            assert list(loss_val.shape) == [n_obs, 50]
+
+            assert np.all(np.isin(
+                pred_val, list(kstat_nystrom.data.data.keys())
+            ))
+            assert np.issubdtype(loss_val.dtype, np.floating)
 
             # group 1 and 2 are very different so we expect 100%
             # prediction on each group (at least for large truncations)
             count_pred = np.count_nonzero(
-                pred[group][:, -10:] == group, axis=0
+                pred_val[:, -10:] == group, axis=0
             )
             np.testing.assert_allclose(count_pred / n_obs, 1, atol=0.1)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -230,7 +230,7 @@ class TestStatistics(object):
         assert isinstance(kstat.bandwidth, str) and kstat.bandwidth == 'median'
         assert isinstance(kstat.median_coef, int) and kstat.median_coef == 1
         assert isinstance(kstat.kernel, types.FunctionType)
-        assert isinstance(kstat.computed_bandwidth, t.Tensor) and \
+        assert isinstance(kstat.computed_bandwidth, to.Tensor) and \
             len(kstat.computed_bandwidth.shape) == 0 and \
             kstat.computed_bandwidth.dtype == to.float64
         assert kstat.sp is None

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -381,6 +381,62 @@ class TestStatistics:
 
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
+    def test_compute_gram(self, kstat, kstat_nystrom, data_shape):
+        # Case 1 – full data, no landmarks, no new_obs
+        # default: landmarks=False, new_obs=None
+        K = kstat.compute_gram()
+
+        # Expected Gram matrix using the same gaussian kernel
+        D = t.cat(tuple(kstat.data.data.values()), dim=0)
+        expected = kstat.kernel(D, D)
+
+        assert isinstance(K, t.Tensor)
+        assert K.shape == (data_shape[0], data_shape[0])
+        t.testing.assert_close(K, expected)
+
+        # Case 2 – compute K(D, new_obs)
+        # New observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+
+        K = kstat.compute_gram(new_obs=new_obs)
+
+        # Expected Gram matrix using the same gaussian kernel
+        D = t.cat(tuple(kstat.data.data.values()), dim=0)
+        expected = kstat.kernel(D, new_obs)
+
+        assert isinstance(K, t.Tensor)
+        assert K.shape == (data_shape[0], new_obs.shape[0])
+        t.testing.assert_close(K, expected)
+
+        # Case 3 – landmarks=True and a Nyström dataset is provided
+        K = kstat_nystrom.compute_gram(landmarks=True)
+
+        # Expected Gram matrix using the same gaussian kernel
+        D = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        expected = kstat_nystrom.kernel(D, D)
+
+        assert isinstance(K, t.Tensor)
+        assert K.shape == (data_shape[0]//5, data_shape[0]//5)
+        t.testing.assert_close(K, expected)
+
+        # Case 4 – landmarks=True but a Nyström dataset is not provided
+        with pytest.raises(ValueError, match="Cannot use landmarks"):
+            K = kstat.compute_gram(landmarks=True)
+
+        # Case 5 – compute K(D, new_obs) with landmarks=True
+        # New observations: use one population subsample
+        new_obs = list(kstat.data.data.values())[0]
+
+        K = kstat_nystrom.compute_gram(landmarks=True, new_obs=new_obs)
+
+        # Expected Gram matrix using the same gaussian kernel
+        D = t.cat(tuple(kstat_nystrom.data_ny.data.values()), dim=0)
+        expected = kstat_nystrom.kernel(D, new_obs)
+
+        assert isinstance(K, t.Tensor)
+        assert K.shape == (data_shape[0]//5, new_obs.shape[0])
+        t.testing.assert_close(K, expected)
+
     def test_compute_centered_gram(self, kstat, kstat_nystrom, data_shape):
         """
         Testing centered Gram matrix computation,

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 import torch as t
 import types
@@ -382,7 +383,7 @@ class TestStatistics:
         np.testing.assert_allclose(res.numpy(), exp_res, rtol=0, atol=1e-11)
 
     def test_compute_gram(self, kstat, kstat_nystrom, data_shape):
-        # Case 1 – full data, no landmarks, no new_obs
+        # Case 1 - full data, no landmarks, no new_obs
         # default: landmarks=False, new_obs=None
         K = kstat.compute_gram()
 
@@ -394,8 +395,8 @@ class TestStatistics:
         assert K.shape == (data_shape[0], data_shape[0])
         t.testing.assert_close(K, expected)
 
-        # Case 2 – compute K(D, new_obs)
-        # New observations: use one population subsample
+        # Case 2 - compute K(D, new_obs)
+        # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
 
         K = kstat.compute_gram(new_obs=new_obs)
@@ -408,7 +409,7 @@ class TestStatistics:
         assert K.shape == (data_shape[0], new_obs.shape[0])
         t.testing.assert_close(K, expected)
 
-        # Case 3 – landmarks=True and a Nyström dataset is provided
+        # Case 3 - landmarks=True and a Nyström dataset is provided
         K = kstat_nystrom.compute_gram(landmarks=True)
 
         # Expected Gram matrix using the same gaussian kernel
@@ -419,12 +420,12 @@ class TestStatistics:
         assert K.shape == (data_shape[0]//5, data_shape[0]//5)
         t.testing.assert_close(K, expected)
 
-        # Case 4 – landmarks=True but a Nyström dataset is not provided
+        # Case 4 - landmarks=True but a Nyström dataset is not provided
         with pytest.raises(ValueError, match="Cannot use landmarks"):
             K = kstat.compute_gram(landmarks=True)
 
-        # Case 5 – compute K(D, new_obs) with landmarks=True
-        # New observations: use one population subsample
+        # Case 5 - compute K(D, new_obs) with landmarks=True
+        # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
 
         K = kstat_nystrom.compute_gram(landmarks=True, new_obs=new_obs)
@@ -438,13 +439,13 @@ class TestStatistics:
         t.testing.assert_close(K, expected)
 
     def test_compute_kmn(self, kstat, kstat_nystrom, data_shape):
-        # Case 0 – not using Nystrom
+        # Case 0 - not using Nystrom
         with pytest.raises(
             AttributeError, match="'NoneType' object has no attribute 'data'"
         ):
             Kmn = kstat.compute_kmn()
 
-        # Case 1 – full data, no new_obs
+        # Case 1 - full data, no new_obs
         # default: new_obs=None
         Kmn = kstat_nystrom.compute_kmn()
 
@@ -458,8 +459,8 @@ class TestStatistics:
         t.testing.assert_close(Kmn, expected)
 
 
-        # Case 2 – compute K(landmarks, new_obs)
-        # New observations: use one population subsample
+        # Case 2 - compute K(landmarks, new_obs)
+        # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
 
         Kmn = kstat_nystrom.compute_kmn(new_obs=new_obs)
@@ -611,3 +612,133 @@ class TestStatistics:
             exp_ev[:, exp_sp >= 1e-12],
             rtol=0, atol=1e-12
         )
+
+    def test_compute_upk(self, kstat, kstat_nystrom, data_shape):
+        # FIXME: only result format is tested, not result values
+
+        # Case 1 - full data (no Nystrom), no new_obs
+        # default: new_obs=None
+        upk = kstat.compute_upk(t=10)
+
+        assert isinstance(upk, t.Tensor)
+        assert upk.shape == (data_shape[0], 10)
+
+        # Case 2 - providing new obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+
+        upk = kstat.compute_upk(t=10, new_obs=new_obs)
+
+        assert isinstance(upk, t.Tensor)
+        assert upk.shape == (new_obs.shape[0], 10)
+
+        # Case 3 - Nystrom, no new_obs
+        # default: new_obs=None
+        upk = kstat_nystrom.compute_upk(t=10)
+
+        assert isinstance(upk, t.Tensor)
+        assert upk.shape == (data_shape[0], 10)
+
+        # Case 4 - Nystrom, providing new obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+
+        upk = kstat_nystrom.compute_upk(t=10, new_obs=new_obs)
+
+        assert isinstance(upk, t.Tensor)
+        assert upk.shape == (new_obs.shape[0], 10)
+
+    def test_compute_projections(self, kstat, kstat_nystrom):
+        # FIXME: only result format is tested, not result values
+
+        def _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val):
+            """Function to check projection results on the fly."""
+            assert isinstance(proj_kfda, dict)
+            assert len(proj_kfda) == len(n_obs_val)
+            assert isinstance(proj_kpca, dict)
+            assert len(proj_kpca) == len(n_obs_val)
+
+            for proj_kfda_tab, proj_kpca_tab, n_obs in zip(
+                proj_kfda.values(), proj_kpca.values(), n_obs_val
+            ):
+                assert isinstance(proj_kfda_tab, pd.DataFrame)
+                assert proj_kfda_tab.shape == (n_obs, t_val)
+                assert isinstance(proj_kpca_tab, pd.DataFrame)
+                assert proj_kpca_tab.shape == (n_obs, t_val)
+
+        # Case 1 - full data (no Nystrom), no centering, no new_obs
+        # default: new_obs=None
+        stat_val, _ = kstat.compute_kfda()
+        proj_kfda, proj_kpca = kstat.compute_projections(
+            stat=stat_val, t=10, center=False
+        )
+        n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 2 - full data (no Nystrom), centering, no new_obs
+        # default: new_obs=None
+        stat_val, _ = kstat.compute_kfda()
+        proj_kfda, proj_kpca = kstat.compute_projections(
+            stat=stat_val, t=10, center=True
+        )
+        n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 3 - full data (no Nystrom), no centering, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+        stat_val, _ = kstat.compute_kfda()
+        proj_kfda, proj_kpca = kstat.compute_projections(
+            stat=stat_val, t=10, center=False, new_obs=new_obs
+        )
+        n_obs_val = [new_obs.shape[0]]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 4 - full data (no Nystrom), centering, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+        stat_val, _ = kstat.compute_kfda()
+        proj_kfda, proj_kpca = kstat.compute_projections(
+            stat=stat_val, t=10, center=True, new_obs=new_obs
+        )
+        n_obs_val = [new_obs.shape[0]]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 5 - full data (no Nystrom), no centering, no new_obs
+        # default: new_obs=None
+        stat_val, _ = kstat_nystrom.compute_kfda()
+        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+            stat=stat_val, t=10, center=False
+        )
+        n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 6 - full data (no Nystrom), centering, no new_obs
+        # default: new_obs=None
+        stat_val, _ = kstat_nystrom.compute_kfda()
+        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+            stat=stat_val, t=10, center=True
+        )
+        n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 7 - full data (no Nystrom), no centering, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+        stat_val, _ = kstat_nystrom.compute_kfda()
+        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+            stat=stat_val, t=10, center=False, new_obs=new_obs
+        )
+        n_obs_val = [new_obs.shape[0]]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+
+        # Case 8 - full data (no Nystrom), centering, providing new_obs
+        # new observations: use one population subsample
+        new_obs = list(kstat_nystrom.data.data.values())[0]
+        stat_val, _ = kstat_nystrom.compute_kfda()
+        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+            stat=stat_val, t=10, center=True, new_obs=new_obs
+        )
+        n_obs_val = [new_obs.shape[0]]
+        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -9,7 +9,9 @@ import warnings
 
 from ktest.tester import Ktest
 
-from .test_data import data_shape, dummy_data, dummy_zidata
+from .test_data import (
+    data_shape, dummy_data_array, dummy_data, dummy_zidata, dummy_separated_data
+)
 
 
 @pytest.fixture
@@ -375,3 +377,202 @@ def test_ktest_project(dummy_ktest):
         assert proj_kpca_tab.shape == (new_obs.shape[0], 10)
         pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
 
+
+def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
+    """Test cross-validation for kFDA prediction."""
+
+    # Case 1a - data under H0, a single prediction bias (threshold) value
+    # no bias
+    # create ktest objects
+    kt = dummy_ktest()
+    # run CV
+    accuracy, true_pos, true_neg = kt.cv(
+        t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
+        random_state=None, verbose=1
+    )
+    # check stdout (expect output)
+    captured = capsys.readouterr()
+    assert captured.out == 'Starting cross-validation...' + \
+        '\nSplit 0\nSplit 1\nSplit 2\nSplit 3\nSplit 4\n' + \
+        '...Aggregating CV fold results\n'
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    assert len(accuracy) == 1
+    assert len(true_pos) == 1
+    assert len(true_neg) == 1
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (50,)
+        assert true_pos_tab.shape == (50,)
+        assert true_neg_tab.shape == (50,)
+
+        # value (expect 50%-50% accuracy)
+        np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
+        np.testing.assert_allclose(true_pos_tab, 1/2, atol=0.1)
+        np.testing.assert_allclose(true_neg_tab, 1/2, atol=0.1)
+
+    # Case 1b - data under H0, a single prediction bias (threshold) value
+    # bias towards ref group
+    # create ktest objects
+    kt = dummy_ktest()
+    # run CV
+    accuracy, true_pos, true_neg = kt.cv(
+        t=50, pred_threshold=1, n_fold=5, n_repeat=1,
+        random_state=None, verbose=0
+    )
+
+    # check stdout (expect no output)
+    captured = capsys.readouterr()
+    assert captured.out == ''
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    assert len(accuracy) == 1
+    assert len(true_pos) == 1
+    assert len(true_neg) == 1
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (50,)
+        assert true_pos_tab.shape == (50,)
+        assert true_neg_tab.shape == (50,)
+
+        # value (expect 50%-50% accuracy but biased sens/spec)
+        np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
+        np.testing.assert_allclose(true_pos_tab, 1, atol=0.1)
+        np.testing.assert_allclose(true_neg_tab, 0, atol=0.1)
+
+    # Case 1c - data under H0, a single prediction bias (threshold) value
+    # bias towards non ref group
+    # create ktest objects
+    kt = dummy_ktest()
+    # run CV
+    accuracy, true_pos, true_neg = kt.cv(
+        t=50, pred_threshold=0, n_fold=5, n_repeat=1,
+        random_state=None, verbose=0
+    )
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    assert len(accuracy) == 1
+    assert len(true_pos) == 1
+    assert len(true_neg) == 1
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (50,)
+        assert true_pos_tab.shape == (50,)
+        assert true_neg_tab.shape == (50,)
+
+        # value (expect 50%-50% accuracy but biased sens/spec)
+        np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
+        np.testing.assert_allclose(true_pos_tab, 0, atol=0.1)
+        np.testing.assert_allclose(true_neg_tab, 1, atol=0.1)
+
+    # Case 2 - data under H0, multiple prediction bias (threshold) values
+    # create ktest objects
+    kt = dummy_ktest()
+    # run CV
+    threshold_values = np.linspace(0, 1, 11)
+    accuracy, true_pos, true_neg = kt.cv(
+        t=50, pred_threshold=threshold_values, n_fold=5, n_repeat=1,
+        random_state=None, verbose=0
+    )
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    assert len(accuracy) == len(threshold_values)
+    assert len(true_pos) == len(threshold_values)
+    assert len(true_neg) == len(threshold_values)
+
+    for accuracy_tab, true_pos_tab, true_neg_tab, pred_threshold in zip(
+        accuracy, true_pos, true_neg, threshold_values
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (50,)
+        assert true_pos_tab.shape == (50,)
+        assert true_neg_tab.shape == (50,)
+
+        # value (expect 50%-50% accuracy)
+        np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
+        np.testing.assert_allclose(true_pos_tab, pred_threshold, atol=0.3)
+        np.testing.assert_allclose(true_neg_tab, 1-pred_threshold, atol=0.3)
+
+    # Case 3 - data under H1
+    # create ktest objects
+    kt = Ktest(
+        data=dummy_separated_data[0],
+        metadata=dummy_separated_data[1],
+        nystrom=True
+    )
+    # run CV
+    accuracy, true_pos, true_neg = kt.cv(
+        t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
+        random_state=None, verbose=1
+    )
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    assert len(accuracy) == 1
+    assert len(true_pos) == 1
+    assert len(true_neg) == 1
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (50,)
+        assert true_pos_tab.shape == (50,)
+        assert true_neg_tab.shape == (50,)
+
+        # value (expect almost 100% accuracy for non-small truncations)
+        np.testing.assert_allclose(accuracy_tab[10:], 1, atol=0.1)
+        np.testing.assert_allclose(true_pos_tab[10:], 1, atol=0.1)
+        np.testing.assert_allclose(true_neg_tab[10:], 1, atol=0.1)

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -378,6 +378,381 @@ def test_ktest_project(dummy_ktest):
         pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
 
 
+def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
+    """Testing prediction in Ktest class."""
+
+    # Case 1a - no new obs, a single prediction bias (threshold) value
+    # (no bias)
+    # data under H0
+
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=None, pred_threshold=0.5, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert pred.keys() == kt.data.data.keys()
+    assert loss.keys() == kt.data.data.keys()
+
+    for group in kt.data.data.keys():
+        n_obs = kt.data.data[group].shape[0]
+
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
+
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
+
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
+
+        # group 1 and 2 are similar so we expect 50%-50% prediction
+        count_pred = np.count_nonzero(pred_val == group, axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+    # Case 1b - full data (no Nystrom), no new_obs,
+    # with a list of threshold values
+    # default: new_obs=None
+    threshold_values = np.linspace(0, 1, 11)
+
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=None, pred_threshold=threshold_values, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert pred.keys() == kt.data.data.keys()
+    assert loss.keys() == kt.data.data.keys()
+
+    for group_ind, group in enumerate(kt.data.data.keys()):
+        n_obs = kt.data.data[group].shape[0]
+
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
+
+        assert len(pred[group]) == len(threshold_values)
+        assert len(loss[group]) == len(threshold_values)
+
+        for pred_val, loss_val, pred_threshold in zip(
+            pred[group], loss[group], threshold_values
+        ):
+
+            assert isinstance(pred_val, np.ndarray)
+            assert isinstance(loss_val, np.ndarray)
+
+            assert list(pred_val.shape) == [n_obs, 10]
+            assert list(loss_val.shape) == [n_obs, 10]
+
+            assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
+            assert np.issubdtype(loss_val.dtype, np.floating)
+
+            # group 1 and 2 are similar so we expect a prediction
+            # corresponding to the bias
+            # (or 1 - bias depending on the group)
+            count_pred = np.count_nonzero(pred_val == group, axis=0)
+            np.testing.assert_allclose(
+                count_pred / n_obs,
+                (1 - group_ind) * pred_threshold +
+                group_ind * (1 - pred_threshold),
+                atol=0.3
+            )
+
+    # Case 2a - full data (no Nystrom), providing new_obs
+    # new observations: use one population subsample
+
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # new data
+    new_obs = list(kt.data.data.values())[0]
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=new_obs, pred_threshold=0.5, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert list(pred.keys()) == ["new_obs"]
+    assert list(loss.keys()) == ["new_obs"]
+
+    group = "new_obs"
+    n_obs = new_obs.shape[0]
+
+    assert isinstance(pred[group], list)
+    assert isinstance(loss[group], list)
+
+    assert len(pred[group]) == 1
+    assert len(loss[group]) == 1
+
+    pred_val = pred[group][0]
+    loss_val = loss[group][0]
+
+    assert isinstance(pred_val, np.ndarray)
+    assert isinstance(loss_val, np.ndarray)
+
+    assert list(pred_val.shape) == [n_obs, 10]
+    assert list(loss_val.shape) == [n_obs, 10]
+
+    assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
+    assert np.issubdtype(loss_val.dtype, np.floating)
+
+    # group 1 and 2 are similar so we expect 50%-50% prediction
+    count_pred = np.count_nonzero(pred_val == "c1", axis=0)
+    np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+    # Case 2b - full data (no Nystrom), providing new_obs,
+    # biasing prediction (expect only group 2 prediction)
+    # new observations: use one population subsample
+
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # new data
+    new_obs = list(kt.data.data.values())[0]
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=new_obs, pred_threshold=0, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert list(pred.keys()) == ["new_obs"]
+    assert list(loss.keys()) == ["new_obs"]
+
+    group = "new_obs"
+    n_obs = new_obs.shape[0]
+
+    assert isinstance(pred[group], list)
+    assert isinstance(loss[group], list)
+
+    assert len(pred[group]) == 1
+    assert len(loss[group]) == 1
+
+    pred_val = pred[group][0]
+    loss_val = loss[group][0]
+
+    assert isinstance(pred_val, np.ndarray)
+    assert isinstance(loss_val, np.ndarray)
+
+    assert list(pred_val.shape) == [n_obs, 10]
+    assert list(loss_val.shape) == [n_obs, 10]
+
+    assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
+    assert np.issubdtype(loss_val.dtype, np.floating)
+
+    # we expect only "group 2" prediction
+    count_pred = np.count_nonzero(pred_val == "c1", axis=0)
+    np.testing.assert_allclose(count_pred / n_obs, 0, atol=0)
+
+    # Case 2c - full data (no Nystrom), providing new_obs,
+    # biasing prediction (expect only group 1 prediction)
+    # new observations: use one population subsample
+
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # new data
+    new_obs = list(kt.data.data.values())[0]
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=new_obs, pred_threshold=1, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert list(pred.keys()) == ["new_obs"]
+    assert list(loss.keys()) == ["new_obs"]
+
+    group = "new_obs"
+    n_obs = new_obs.shape[0]
+
+    assert isinstance(pred[group], list)
+    assert isinstance(loss[group], list)
+
+    assert len(pred[group]) == 1
+    assert len(loss[group]) == 1
+
+    pred_val = pred[group][0]
+    loss_val = loss[group][0]
+
+    assert isinstance(pred_val, np.ndarray)
+    assert isinstance(loss_val, np.ndarray)
+
+    assert list(pred_val.shape) == [n_obs, 10]
+    assert list(loss_val.shape) == [n_obs, 10]
+
+    assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
+    assert np.issubdtype(loss_val.dtype, np.floating)
+
+    # we expect only "group 1" prediction
+    count_pred = np.count_nonzero(pred_val == "c1", axis=0)
+    np.testing.assert_allclose(count_pred / n_obs, 1, atol=0)
+
+    # Case 3 - Nystrom approximation, no new_obs
+    # default: new_obs=None
+
+    # create ktest objects
+    kt = dummy_ktest(nystrom=True)
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=None, pred_threshold=0.5, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert pred.keys() == kt.data.data.keys()
+    assert loss.keys() == kt.data.data.keys()
+
+    for group in kt.data.data.keys():
+        n_obs = kt.data.data[group].shape[0]
+
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
+
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
+
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(
+            pred_val, list(kt.data.data.keys())
+        ))
+        assert np.issubdtype(loss_val.dtype, np.floating)
+
+        # group 1 and 2 are similar so we expect 50%-50% prediction
+        count_pred = np.count_nonzero(pred_val == group, axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+    # Case 4 - Nystrom approximation, providing new_obs
+    # new observations: use one population subsample
+
+    # create ktest objects
+    kt = dummy_ktest(nystrom=True)
+
+    # new data
+    new_obs = list(kt.data.data.values())[0]
+
+    # run CV
+    pred, loss = kt.predict(
+        t=10, new_obs=new_obs, pred_threshold=1/2, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert list(pred.keys()) == ["new_obs"]
+    assert list(loss.keys()) == ["new_obs"]
+
+    group = "new_obs"
+    n_obs = new_obs.shape[0]
+
+    assert isinstance(pred[group], list)
+    assert isinstance(loss[group], list)
+
+    assert len(pred[group]) == 1
+    assert len(loss[group]) == 1
+
+    pred_val = pred[group][0]
+    loss_val = loss[group][0]
+
+    assert isinstance(pred_val, np.ndarray)
+    assert isinstance(loss_val, np.ndarray)
+
+    assert list(pred_val.shape) == [n_obs, 10]
+    assert list(loss_val.shape) == [n_obs, 10]
+
+    assert np.all(np.isin(pred_val, list(kt.data_nystrom.data.keys())))
+    assert np.issubdtype(loss_val.dtype, np.floating)
+
+    # group 1 and 2 are similar so we expect 50%-50% prediction
+    count_pred = np.count_nonzero(pred_val == "c1", axis=0)
+    np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+    # Case 5 - separated data (Nystrom approximation, no new_obs)
+
+    # create ktest objects
+    kt = Ktest(
+        data=dummy_separated_data[0],
+        metadata=dummy_separated_data[1],
+        nystrom=True
+    )
+
+    # run CV
+    pred, loss = kt.predict(
+        t=50, new_obs=None, pred_threshold=1/2, verbose=1
+    )
+
+    # check
+    assert isinstance(pred, dict)
+    assert isinstance(loss, dict)
+    assert pred.keys() == kt.data.data.keys()
+    assert loss.keys() == kt.data.data.keys()
+
+    for i, group in enumerate(kt.data.data.keys()):
+        n_obs = kt.data.data[group].shape[0]
+
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
+
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
+
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 50]
+        assert list(loss_val.shape) == [n_obs, 50]
+
+        assert np.all(np.isin(
+            pred_val, list(kt.data.data.keys())
+        ))
+        assert np.issubdtype(loss_val.dtype, np.floating)
+
+        # group 1 and 2 are very different so we expect 100%
+        # prediction on each group (at least for large truncations)
+        count_pred = np.count_nonzero(
+            pred_val[:, -10:] == group, axis=0
+        )
+        np.testing.assert_allclose(count_pred / n_obs, 1, atol=0.1)
+
+
 def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     """Test cross-validation for kFDA prediction."""
 

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -34,7 +34,7 @@ def dummy_ktest(dummy_data):
 
 @pytest.mark.parametrize("nystrom", [False, True])
 @pytest.mark.parametrize("dtype", [t.float64, t.float32])
-def test_Ktest(dummy_ktest, dummy_data, nystrom, dtype):
+def test_ktest(dummy_ktest, dummy_data, nystrom, dtype):
     """Testing Ktest class."""
     # create ktest objects
     kt = dummy_ktest(nystrom, dtype)
@@ -230,3 +230,148 @@ def test_zi_data(dummy_zidata, data_shape, nystrom):
     kt = Ktest(data=dummy_zidata[0], metadata=dummy_zidata[1], nystrom=nystrom)
     # run kfda test
     kt.test(verbose=0)
+
+
+def test_ktest_project(dummy_ktest):
+    """Testing projection in Ktest class."""
+    # create ktest objects
+    kt = dummy_ktest()
+
+    # Case 1 - centering, no new obs
+    proj_kfda, proj_kpca = kt.project(
+        t=10, center=True, verbose=1, new_obs=None
+    )
+
+    # expected results
+    stat_val, _ = kt.kstat.compute_kfda()
+    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+        stat=stat_val, t=10, center=True
+    )
+
+    # check
+    assert isinstance(proj_kfda, dict)
+    assert len(proj_kfda) == len(exp_proj_kfda)
+    assert proj_kfda.keys() == exp_proj_kfda.keys()
+    assert isinstance(proj_kpca, dict)
+    assert len(proj_kpca) == len(exp_proj_kpca)
+    assert proj_kpca.keys() == exp_proj_kpca.keys()
+
+    for (
+        proj_kfda_tab, exp_proj_kfda_tab,
+        proj_kpca_tab, exp_proj_kpca_tab,
+        data_tab
+    ) in zip(
+        proj_kfda.values(), exp_proj_kfda.values(),
+        proj_kpca.values(), exp_proj_kpca.values(),
+        kt.data.data.values()
+    ):
+        assert isinstance(proj_kfda_tab, pd.DataFrame)
+        assert proj_kfda_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
+        assert isinstance(proj_kpca_tab, pd.DataFrame)
+        assert proj_kpca_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+
+    # Case 2 - not centering, no new obs
+    proj_kfda, proj_kpca = kt.project(
+        t=10, center=False, verbose=1, new_obs=None
+    )
+
+    # expected results
+    stat_val, _ = kt.kstat.compute_kfda()
+    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+        stat=stat_val, t=10, center=False
+    )
+
+    # check
+    assert isinstance(proj_kfda, dict)
+    assert len(proj_kfda) == len(exp_proj_kfda)
+    assert proj_kfda.keys() == exp_proj_kfda.keys()
+    assert isinstance(proj_kpca, dict)
+    assert len(proj_kpca) == len(exp_proj_kpca)
+    assert proj_kpca.keys() == exp_proj_kpca.keys()
+
+    for (
+        proj_kfda_tab, exp_proj_kfda_tab,
+        proj_kpca_tab, exp_proj_kpca_tab,
+        data_tab
+    ) in zip(
+        proj_kfda.values(), exp_proj_kfda.values(),
+        proj_kpca.values(), exp_proj_kpca.values(),
+        kt.data.data.values()
+    ):
+        assert isinstance(proj_kfda_tab, pd.DataFrame)
+        assert proj_kfda_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
+        assert isinstance(proj_kpca_tab, pd.DataFrame)
+        assert proj_kpca_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+
+    # Case 3 - centering, providing new obs
+    new_obs = list(kt.kstat.data.data.values())[0]
+    proj_kfda, proj_kpca = kt.project(
+        t=10, center=True, verbose=1, new_obs=new_obs
+    )
+
+    # expected results
+    stat_val, _ = kt.kstat.compute_kfda()
+    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+        stat=stat_val, t=10, center=True, new_obs=new_obs
+    )
+
+    # check
+    assert isinstance(proj_kfda, dict)
+    assert len(proj_kfda) == len(exp_proj_kfda)
+    assert proj_kfda.keys() == exp_proj_kfda.keys()
+    assert isinstance(proj_kpca, dict)
+    assert len(proj_kpca) == len(exp_proj_kpca)
+    assert proj_kpca.keys() == exp_proj_kpca.keys()
+
+    for (
+        proj_kfda_tab, exp_proj_kfda_tab,
+        proj_kpca_tab, exp_proj_kpca_tab
+    ) in zip(
+        proj_kfda.values(), exp_proj_kfda.values(),
+        proj_kpca.values(), exp_proj_kpca.values()
+    ):
+        assert isinstance(proj_kfda_tab, pd.DataFrame)
+        assert proj_kfda_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
+        assert isinstance(proj_kpca_tab, pd.DataFrame)
+        assert proj_kpca_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+
+    # Case 4 - not centering, providing new obs
+    new_obs = list(kt.kstat.data.data.values())[0]
+    proj_kfda, proj_kpca = kt.project(
+        t=10, center=False, verbose=1, new_obs=new_obs
+    )
+
+    # expected results
+    stat_val, _ = kt.kstat.compute_kfda()
+    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+        stat=stat_val, t=10, center=False, new_obs=new_obs
+    )
+
+    # check
+    assert isinstance(proj_kfda, dict)
+    assert len(proj_kfda) == len(exp_proj_kfda)
+    assert proj_kfda.keys() == exp_proj_kfda.keys()
+    assert isinstance(proj_kpca, dict)
+    assert len(proj_kpca) == len(exp_proj_kpca)
+    assert proj_kpca.keys() == exp_proj_kpca.keys()
+
+    for (
+        proj_kfda_tab, exp_proj_kfda_tab,
+        proj_kpca_tab, exp_proj_kpca_tab
+    ) in zip(
+        proj_kfda.values(), exp_proj_kfda.values(),
+        proj_kpca.values(), exp_proj_kpca.values()
+    ):
+        assert isinstance(proj_kfda_tab, pd.DataFrame)
+        assert proj_kfda_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
+        assert isinstance(proj_kpca_tab, pd.DataFrame)
+        assert proj_kpca_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import torch as to
 
-from ktest.utils import verbosity, pred_threshold_fun
+from ktest.utils import verbosity, pred_threshold_fun, compute_accuracy
 
 
 torch_assert_equal = functools.partial(to.testing.assert_close, rtol=0, atol=0)
@@ -128,3 +128,121 @@ def test_pred_threshold_fun():
         torch_assert_equal(res, 2 * right_val * x - right_val)
 
 
+def test_compute_accuracy():
+    """Testing function computing accuracy in kFDA cross-validation."""
+
+    # Pseudo-random number generator
+    rng = np.random.default_rng(42)
+
+    # consider 2-level factor
+    group_name = np.array(['c1', 'c2'])
+
+    # Case 1a: prediction = ground truth (expect no error), ref is provided
+    # ground truth
+    ground_truth_index = rng.choice([0, 1], size=(20,)).astype(np.uint)
+    ground_truth = group_name[ground_truth_index]
+    # create prediction
+    prediction_index = [np.repeat(ground_truth_index[:, None], 10, axis=1)]
+    prediction = [group_name[tab] for tab in prediction_index]
+
+    # try computing accuracy
+    accuracy, true_pos, true_neg = compute_accuracy(
+        prediction, ground_truth, ref=group_name[0]
+    )
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (20, 10)
+        ref = group_name[0]
+        assert true_pos_tab.shape == \
+            (np.sum(ground_truth == ref), 10)
+        assert true_neg_tab.shape == \
+            (np.sum(ground_truth != ref), 10)
+
+        # value
+        assert np.all(accuracy_tab == 1)
+        assert np.all(true_pos_tab == 1)
+        assert np.all(true_neg_tab == 1)
+
+    # Case 1b: prediction = ground truth (expect no error), ref is not provided
+    # try computing accuracy
+    accuracy, true_pos, true_neg = compute_accuracy(
+        prediction, ground_truth, ref=group_name[0]
+    )
+
+    # check output
+    assert isinstance(accuracy, list)
+    assert isinstance(true_pos, list)
+    assert isinstance(true_neg, list)
+
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        # type
+        assert isinstance(accuracy_tab, np.ndarray)
+        assert isinstance(true_pos_tab, np.ndarray)
+        assert isinstance(true_neg_tab, np.ndarray)
+
+        # dimension
+        assert accuracy_tab.shape == (20, 10)
+        ref = ground_truth[0]
+        assert true_pos_tab.shape == \
+            (np.sum(ground_truth == ref), 10)
+        assert true_neg_tab.shape == \
+            (np.sum(ground_truth != ref), 10)
+
+        # value
+        assert np.all(accuracy_tab == 1)
+        assert np.all(true_pos_tab == 1)
+        assert np.all(true_neg_tab == 1)
+
+    # Case 2: prediction = 1 - ground truth (expect only errors)
+    # create prediction
+    prediction = [group_name[1 - tab] for tab in prediction_index]
+
+    # try computing accuracy
+    accuracy, true_pos, true_neg = compute_accuracy(
+        prediction, ground_truth, ref=group_name[0]
+    )
+
+    # check
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        assert np.all(accuracy_tab == 0)
+        assert np.all(true_pos_tab == 0)
+        assert np.all(true_neg_tab == 0)
+
+    # Case 3: multiple random predictions
+    # generate data (list of 2-level factor arrays)
+    prediction = []
+    rng = np.random.default_rng(42)
+    for i in range(10):
+        prediction.append(
+            rng.choice(group_name, size=(20, 10))
+        )
+
+    # try computing accuracy
+    accuracy, true_pos, true_neg = compute_accuracy(
+        prediction, ground_truth, ref=group_name[0]
+    )
+
+    # check
+    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
+        accuracy, true_pos, true_neg
+    ):
+        assert np.all(np.isin(accuracy_tab, [0, 1]))
+        assert np.all(np.isin(true_pos_tab, [0, 1]))
+        assert np.all(np.isin(true_neg_tab, [0, 1]))

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,6 +1,12 @@
+import functools
 import pytest
+import numpy as np
+import torch as to
 
-from ktest.utils import verbosity
+from ktest.utils import verbosity, pred_threshold_fun
+
+
+torch_assert_equal = functools.partial(to.testing.assert_close, rtol=0, atol=0)
 
 
 def test_verbosity(capsys, recwarn):
@@ -81,4 +87,44 @@ def test_verbosity(capsys, recwarn):
     with pytest.raises(AssertionError) as excinfo:
         verbosity(msg="this is a message", msg_type="print", verbose="0")
     assert str(excinfo.value) == err_msg
+
+
+def test_pred_threshold_fun():
+    """Testing function that define biased prediction threshold."""
+
+    # testing scalar value input for left/right value parameters
+    for left_val, right_val in zip(
+        [5, 10, 15, 20, 40, 50], reversed([5, 10, 15, 20, 40, 50])
+    ):
+
+        # at x=0, y should be -left_val
+        assert pred_threshold_fun(0, left_val, right_val) == -left_val
+        # at x=0.5, y should be 0
+        assert pred_threshold_fun(0.5, left_val, right_val) == 0
+        # at x=1, y should be right_val
+        assert pred_threshold_fun(1, left_val, right_val) == right_val
+
+    # testing array-like input for left/right value parameters
+    # numpy array input
+    left_val = np.array([5, 10, 15, 20, 40, 50])
+    right_val = left_val[::-1]
+
+    for x in np.linspace(0, 0.5, 100):
+        res = pred_threshold_fun(x, left_val, right_val)
+        np.testing.assert_equal(res, 2 * left_val * x - left_val)
+    for x in np.linspace(0.5, 1, 100):
+        res = pred_threshold_fun(x, left_val, right_val)
+        np.testing.assert_equal(res, 2 * right_val * x - right_val)
+
+    # torch array input
+    left_val = to.Tensor([5, 10, 15, 20, 40, 50])
+    right_val = left_val.flip(dims=(0,))
+
+    for x in to.linspace(0, 0.5, 100):
+        res = pred_threshold_fun(x, left_val, right_val)
+        torch_assert_equal(res, 2 * left_val * x - left_val)
+    for x in to.linspace(0.5, 1, 100):
+        res = pred_threshold_fun(x, left_val, right_val)
+        torch_assert_equal(res, 2 * right_val * x - right_val)
+
 


### PR DESCRIPTION
1. implement projections to discriminant axis for new observations
2. implement kFDA predictions in feature space for training data or new observations
3. implement V-fold cross-validation for kFDA prediction
4. Other minor modifications

Details:

* 33a14d8 bump package version (v1.1.2 -> v1.2.0)
* 0ed85c2 implement unit test for Ktest.predict()
* bc2ed55 implement unit tests for cross-validation
* ce46afd minor (adding a comment)
* 9e4602c implement functions for kFDA prediction and cross-validation in Ktest object
* c3b8ca5 minor refactoring in projection function (docstring, input check and conversion, code linting)
* 93b10b4 reorganize import to follow Python recommandations (first standard library modules, then external packages, then internal modules)
* 4ad1385 fix missing 't' to 'to' torch import renaming
* d8069d8 import missing fixture following modification of data generation fixture
* 9b26647 function to compute accuracy, true positive and true negative indicators over cross-validation folds
* 5b935d8 test Data object init using numpy arrays as data input
* 88f6fd7 [bug fix] fix issue with dimension checking for input data array when not being pandas DataFrame
* 8546618 modify prediction approach output
* acf5ef7 fix docstring
* 1d50707 scripts to run some tests while implementing kFDA prediction + corresponding package requirements
* 9ea32e7 add on option to avoid re-computing the kernel statistic if already computing when doing kFDA prediction
* 54db66e [NEW] implement kFDA loss function compuations and corresponding prediction (+ corresponding unit tests)
* 625d69b modify torch import to avoid confusion with variable 't' + slightly improve some docstrings in tests
* 22b0082 generate a dummy data set for tests where the two groups are sampled from different distribution (to have a dataset under the alternative hypothesis)
* 3f23f23 function to compute threshold used to bias prediction in kFDA toward one group or the other
* 0f20a3e modify centering to avoid any useless computation when not centering
* 4d07744 modify import order (first standard lib modules then other packages) + modify torch import to avoid confusion with variable 't'
* 59493d6 implement projections on kFDA axis for new observations
* 073ecc4 Fix bug when not centering kFDA projections (centering matrix that should be identify in that case was not defined)
* 8412cec fix typo in docstring: confusion between anchors and landmarks
* dc415b1 implement Gram matrix computation with new observations in Nystrom case (i.e. landmarks x data)
* 6aa27fb implement Gram matrix computation with new observations