### PR TITLE
Implement kFDA residual computation

### DIFF
--- a/python/dev/dev_kfda_cv.py
+++ b/python/dev/dev_kfda_cv.py
@@ -1,0 +1,135 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from sklearn.decomposition import PCA
+import torch as to
+
+# from ktest.data import Data
+# from ktest.kernel_statistics import Statistics
+from ktest.tester import Ktest
+
+
+# data shape
+data_shape = [1000, 1000]
+
+# generate random data with different mean in different the 2 groups
+rng = np.random.default_rng(42)
+loc = 0
+loc = np.hstack([
+    np.tile(
+        np.array([-2, 2])[np.arange(data_shape[0]) % 2][:, np.newaxis],
+        (1, 10)
+    ) + rng.normal(loc=0, scale=1, size=[data_shape[0], 10]),
+    np.zeros([data_shape[0], data_shape[1] - 10], dtype=np.float64)
+])
+data_array = rng.normal(loc=loc, scale=2, size=data_shape)
+
+# create a data frame from random gaussian data
+data = pd.DataFrame(
+    data=data_array,
+    columns=[f"col{i+1}" for i in range(data_shape[1])]
+)
+
+# create meta data frame indicating two groups
+meta = pd.Series(
+    data=[f"c{i+1}" for i in range(2)] * (data_shape[0] // 2)
+)
+
+# heatmap of the data matrix
+plt.figure()
+sns.heatmap(pd.concat(
+    [data.iloc[::2], data.iloc[1::2]], ignore_index=True
+))
+plt.savefig("fig/data.png")
+
+# Perform PCA
+pca = PCA(n_components=2)
+transformed_data = pca.fit_transform(data)
+
+print(f"PCA explained variance ratio: {pca.explained_variance_ratio_}")
+
+# plot PCA
+data2plot = pd.DataFrame(transformed_data, columns=['PC1', 'PC2'])
+data2plot["meta"] = meta
+plt.figure()
+sns.scatterplot(data=data2plot, x='PC1', y='PC2', hue="meta")
+plt.savefig("fig/pca.png")
+
+# Kernel test
+kt = Ktest(
+    data=data, metadata=meta, nystrom=False, dtype=to.float64
+)
+kt.test(verbose=0)
+
+print(f"pvalues =\n{kt.kfda_pval_asymp.to_numpy().T[:10]}")
+
+# plot density
+plt.figure()
+kt.plot_density(t=10)
+plt.savefig("fig/density.png")
+
+# projection
+proj_kfda, proj_kpca = kt.project(
+    t=100, center=True, verbose=1, new_obs=None
+)
+
+# plot projection
+data2plot = pd.concat(proj_kfda.values()).sort_index().rename(
+    lambda x: f"t{x}", axis="columns"
+)
+data2plot["meta"] = meta
+
+for t_val in [5, 10, 20, 50, 75, 100]:
+    plt.figure()
+    sns.kdeplot(data=data2plot, x=f"t{t_val}", hue="meta")
+    plt.savefig(f"fig/proj_t{t_val}.png")
+
+# cross-validation
+accuracy, true_pos, true_neg, residuals = kt.cv(
+    t=100, pred_threshold=1/2, n_fold=5, n_repeat=1,
+    random_state=None, verbose=1
+)
+
+# plot prediction performance
+res_df = pd.DataFrame({
+    "accuracy": accuracy[0],
+    "true_pos": true_pos[0],
+    "true_neg": true_neg[0],
+    "t_val": np.arange(100)+1
+})
+
+data2plot = pd.melt(res_df, id_vars=["t_val"])
+
+plt.figure()
+sns.lineplot(
+    x='t_val',
+    y='value',
+    hue='variable',
+    data=data2plot
+)
+plt.savefig(f"fig/cv_res.png")
+
+# plot residuals
+res_df = pd.DataFrame({
+    "accuracy": accuracy[0],
+    "true_pos": true_pos[0],
+    "true_neg": true_neg[0],
+    "t_val": np.arange(100)+1
+})
+
+data2plot = pd.DataFrame({
+    "residuals": residuals[0],
+    "t_val": np.arange(100)+1
+})
+
+plt.figure()
+sns.lineplot(
+    x='t_val',
+    y='residuals',
+    data=data2plot
+)
+plt.savefig(f"fig/cv_residuals.png")
+
+
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.2.2"
+version = "1.3.0"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -944,7 +944,55 @@ class Statistics(object):
         # output
         return distance_group1, distance_group2
 
-    def kfda_predict(self, t=100, new_obs=None, pred_threshold=0.5, stat=None):
+    def kfda_axis_norm2(self, t=100, stat=None):
+        """
+        Computes the kFDA discriminant axis squared norm.
+
+        Parameters
+        ----------
+
+        t: int, optional
+            Maximal truncation, the default is 100.
+
+        stat : Pandas.Series, optional
+            kFDA statistics (same as the attribute `kfda_statistic` of class
+            Ktest). Required for projection normalization. Can be provided as
+            input argument to avoid re-computing it. If `None` (default), then
+            the kFDA statistics is re-computed.
+
+        Returns
+        -------
+
+        kfda_axis_norm2: torch.Tensor
+            1D array containing KFDA discriminant axis squared norm
+            for every truncation values.
+        """
+        # get kFDA stat Value
+        if stat is None:
+            stat, _ = self.compute_kfda()
+
+        # Maximal truncation identification:
+        t = min(t, len(self.sp))
+
+        # Calculating statistic for every truncation:
+        pkm = self.compute_pkm()
+        n1, n2 = self.data.nobs.values()
+        exposant_n = 1 if self.data_ny is not None else 2
+        exposant_sp = 2 if self.data_ny is not None else 3
+
+        # Calculating discriminant axis squared norm for every truncation:
+        kfda_axis_norm2 = \
+            (n1 * n2) / (self.data.ntot ** exposant_n
+                         * self.sp[:t] ** exposant_sp
+                         * to.from_numpy(stat.values[:t])) \
+            * mv(self.ev.T[:t], pkm) ** 2
+        # output
+        return kfda_axis_norm2
+
+    def kfda_predict(
+        self, t=100, new_obs=None, pred_threshold=0.5, stat=None,
+        extended_output=False
+    ):
         """
         Compute prediction for each observations according to kFDA and with
         increasing truncation values, i.e. assign each observations to one of
@@ -974,6 +1022,12 @@ class Statistics(object):
             input argument to avoid re-computing it. If `None` (default), then
             the kFDA statistics is re-computed.
 
+        extended_output : boolean
+            Flag to enable/disable returning additional results, including
+            distances between observation projections and each group
+            mean embedding projections, as well as discriminant axis
+            sqaured norm.
+
         Returns
         -------
 
@@ -990,6 +1044,29 @@ class Statistics(object):
             observations, each array stores kFDA loss function values for each
             considered observation and increasing truncation values, for a
             given prediction threshold given by `pred_threshold`.
+
+        res: dict
+            dictionary containing list of residual value arrays (np.ndarray),
+            either for each group in the training data or for the new
+            observations, each array stores kFDA residual values for each
+            considered observation and increasing truncation values, for a
+            given prediction threshold given by `pred_threshold`.
+
+        distance_group1: dict (optional)
+            dictionary of arrays (torch.Tensor) storing the distance from each
+            observation to the mean embedding of group 1 for increasing
+            truncation, either for each group in the training data or for the
+            new observations.
+
+        distance_group2: dict (optional)
+            dictionary of arrays (torch.Tensor) storing the distance from each
+            observation to the mean embedding of group 2 for increasing
+            truncation, either for each group in the training data or for the
+            new observations.
+
+        axis_norm2: torch.Tensor (optional)
+            1D array containing KFDA discriminant axis squared norm
+            for every truncation values.
         """
 
         # check threshold input and convert to list if scalar
@@ -1009,9 +1086,13 @@ class Statistics(object):
         # compute loss function associated to kFDA prediction
         distance_group1, distance_group2 = self.kfda_loss(t, new_obs, stat)
 
+        # compute discriminant axis squared norm
+        axis_norm2 = self.kfda_axis_norm2(t, stat)
+
         # init output (dictionaries)
-        pred = {}
-        loss = {}
+        pred = {}     # prediction
+        loss = {}     # loss function (with potential bias)
+        res = {}      # residuals
 
         # compute prediction for each observation set
         # iterate through group (or new obs)
@@ -1023,6 +1104,7 @@ class Statistics(object):
             # init intermediate results (for each threshold value)
             pred_inter = []
             loss_inter = []
+            res_inter = []
 
             # compare distances to group 1 and group 2
             diff_g1_g2 = dist_g1 - dist_g2
@@ -1039,15 +1121,30 @@ class Statistics(object):
 
                 # convert loss to group name prediction
                 group_name = np.array(list(self.data.index.keys()))
-                pred_val = group_name[(1 - (loss_val < 0).int()).numpy()]
+                pred_crit = 1 - (loss_val < 0).int()
+                pred_val = group_name[pred_crit.numpy()]
 
                 # store prediction and loss for current set of observations
                 pred_inter.append(pred_val)
                 loss_inter.append(loss_val.numpy())
 
+                # compute residuals
+                res_val = to.sqrt(
+                    ((1 - pred_crit) * dist_g1 + pred_crit * dist_g2)
+                    * axis_norm2[None, :]
+                )
+
+                # store residuals for current set of observations
+                res_inter.append(res_val.numpy())
+
             # store results
             pred[group] = pred_inter
             loss[group] = loss_inter
+            res[group] = res_inter
 
         # output
-        return pred, loss
+        if not extended_output:
+            return pred, loss, res
+        else:
+            return pred, loss, res, distance_group1, distance_group2, \
+                axis_norm2

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -596,7 +596,7 @@ class Ktest(Statistics):
         Returns
         -------
 
-        pred: dict or list of dict
+        kfda_pred: dict or list of dict
             dictionary (or list of dictionaries) of arrays (np.ndarray) storing
             kFDA predictions for each observation and increasing truncation,
             either for each group in the training data or for the new
@@ -604,9 +604,17 @@ class Ktest(Statistics):
             then `pred` is a list corresponding to prediction dictionaries for
             each element in `pred_threshold`.
 
-        loss: dict or list of dict
+        kfda_loss: dict or list of dict
             dictionary (or list of dictionaries) of arrays (np.ndarray) storing
             kFDA loss function values for each observation and increasing
+            truncation, either for each group in the training data or for the
+            new observations. If `pred_threshold` input argument is an
+            Iterable, then `pred` is a list corresponding to prediction
+            dictionaries for each element in `pred_threshold`.
+
+        kfda_res: loss: dict or list of dict
+            dictionary (or list of dictionaries) of arrays (np.ndarray) storing
+            kFDA residual values for each observation and increasing
             truncation, either for each group in the training data or for the
             new observations. If `pred_threshold` input argument is an
             Iterable, then `pred` is a list corresponding to prediction
@@ -641,13 +649,13 @@ class Ktest(Statistics):
                     new_obs = to.from_numpy(new_obs)
 
             # compute prediction
-            kfda_pred, kfda_loss = self.kstat.kfda_predict(
+            kfda_pred, kfda_loss, kfda_res = self.kstat.kfda_predict(
                 t=t, new_obs=new_obs, pred_threshold=pred_threshold,
                 stat=self.kfda_statistic
             )
 
             # output
-            return kfda_pred, kfda_loss
+            return kfda_pred, kfda_loss, kfda_res
 
     def cv(
         self, t=100, pred_threshold=0.5, n_fold=5, n_repeat=1, ref=None,
@@ -710,8 +718,14 @@ class Ktest(Statistics):
             list of 1-D arrays of average true positive rates over
             cross-validation for increasing truncation values, corresponding
             to each prediction threshold bias value(s) provided in input.
-        true_neg : numpy.ndarray
+
+        true_neg : list of numpy.ndarray
             list of 1-D arrays of average true negative rates over
+            cross-validation for increasing truncation values, corresponding
+            to each prediction threshold bias value(s) provided in input.
+
+        residuals : list of numpy.ndarray
+            list of 1-D arrays of average residual values over
             cross-validation for increasing truncation values, corresponding
             to each prediction threshold bias value(s) provided in input.
         """
@@ -770,7 +784,7 @@ class Ktest(Statistics):
                     )
 
                 # define statistic object for training data
-                kstat_perm = Statistics(
+                kstat_train = Statistics(
                     train_data,
                     kernel_function=self.kernel_function,
                     bandwidth=self.kernel_bandwidth,
@@ -782,9 +796,11 @@ class Ktest(Statistics):
                 )
 
                 # compute prediction
-                kfda_pred, kfda_loss = kstat_perm.kfda_predict(
+                kfda_pred, kfda_loss, kfda_res = kstat_train.kfda_predict(
                     t=t,
-                    new_obs=to.from_numpy(self.dataset.iloc[test_index].to_numpy()),
+                    new_obs=to.from_numpy(
+                        self.dataset.iloc[test_index].to_numpy()
+                    ),
                     pred_threshold=pred_threshold,
                     stat=None
                 )
@@ -801,6 +817,7 @@ class Ktest(Statistics):
                     "accuracy": accuracy_res,
                     "true_pos": true_pos_res,
                     "true_neg": true_neg_res,
+                    "residuals": kfda_res["new_obs"],
                     "test_index": test_index
                 })
 
@@ -825,6 +842,9 @@ class Ktest(Statistics):
             true_neg_list = list(map(
                 list, zip(*[d["true_neg"] for d in fold_res])
             ))
+            res_list = list(map(
+                list, zip(*[d["residuals"] for d in fold_res])
+            ))
 
             # compute average accuracy, true pos rate and true neg rate over
             # all folds
@@ -840,9 +860,13 @@ class Ktest(Statistics):
                 np.mean(np.vstack(true_neg_tab_list), axis=0)
                 for true_neg_tab_list in true_neg_list
             ]
+            residuals = [
+                np.mean(np.vstack(res_tab_list), axis=0)
+                for res_tab_list in res_list
+            ]
 
             # output
-            return accuracy, true_pos, true_neg
+            return accuracy, true_pos, true_neg, residuals
 
     def plot_density(
         self, t=None, t_max=100, colors=None, labels=None, alpha=.5,

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -897,6 +897,53 @@ class TestStatistics(object):
             assert np.issubdtype(dist_g1[group].numpy().dtype, np.floating)
             assert np.issubdtype(dist_g2[group].numpy().dtype, np.floating)
 
+    def test_kfda_axis_norm2(
+        self, kstat, kstat_nystrom, ktest_separated_data,
+        ktest_separated_data_nystrom
+    ):
+        """Testing kFDA discriminant axis squard norm computation."""
+
+        # Case 1 - full data (no Nystrom)
+        axis_norm2 = kstat.kfda_axis_norm2(t=10)
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat.dtype
+
+        # Case 2 - full data (no Nystrom), no new_obs, providing stat value
+        stat_val, _ = kstat.compute_kfda()
+        axis_norm2 = kstat.kfda_axis_norm2(t=10, stat=stat_val)
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat.dtype
+
+        # Case 3 - Nystrom approximation
+        axis_norm2 = kstat_nystrom.kfda_axis_norm2(t=10)
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat_nystrom.dtype
+
+        # Case 5 - separated data (Nystrom approximation)
+        # kernel stat object
+        kstat_sep = Statistics(
+            data=ktest_separated_data,
+            kernel_function='gauss',
+            bandwidth='median',
+            median_coef=1,
+            data_nystrom=ktest_separated_data_nystrom,
+            n_anchors=None,
+            anchor_basis='w',
+            eps=None, clip_eigval=True
+        )
+
+        axis_norm2 = kstat_sep.kfda_axis_norm2(t=10)
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat_nystrom.dtype
+
     def test_kfda_predict(
         self, kstat, kstat_nystrom, ktest_separated_data,
         ktest_separated_data_nystrom
@@ -905,33 +952,41 @@ class TestStatistics(object):
 
         # Case 1a - full data (no Nystrom), no new_obs
         # default: new_obs=None
-        pred, loss = kstat.kfda_predict(t=10, pred_threshold=1/2)
+        pred, loss, res = kstat.kfda_predict(t=10, pred_threshold=1/2)
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert pred.keys() == kstat.data.data.keys()
         assert loss.keys() == kstat.data.data.keys()
+        assert res.keys() == kstat.data.data.keys()
 
         for group in kstat.data.data.keys():
             n_obs = kstat.data.data[group].shape[0]
 
             assert isinstance(pred[group], list)
             assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
 
             assert len(pred[group]) == 1
             assert len(loss[group]) == 1
+            assert len(res[group]) == 1
 
             pred_val = pred[group][0]
             loss_val = loss[group][0]
+            res_val = res[group][0]
 
             assert isinstance(pred_val, np.ndarray)
             assert isinstance(loss_val, np.ndarray)
+            assert isinstance(res_val, np.ndarray)
 
             assert list(pred_val.shape) == [n_obs, 10]
             assert list(loss_val.shape) == [n_obs, 10]
+            assert list(res_val.shape) == [n_obs, 10]
 
             assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
             assert np.issubdtype(loss_val.dtype, np.floating)
+            assert np.issubdtype(res_val.dtype, np.floating)
 
             # group 1 and 2 are similar so we expect 50%-50% prediction
             count_pred = np.count_nonzero(pred_val == group, axis=0)
@@ -941,23 +996,27 @@ class TestStatistics(object):
         # with a list of threshold values
         # default: new_obs=None
         threshold_values = np.linspace(0, 1, 11)
-        pred, loss = kstat.kfda_predict(
+        pred, loss, res = kstat.kfda_predict(
             t=10, pred_threshold=threshold_values
         )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert pred.keys() == kstat.data.data.keys()
         assert loss.keys() == kstat.data.data.keys()
+        assert res.keys() == kstat.data.data.keys()
 
         for group_ind, group in enumerate(kstat.data.data.keys()):
             n_obs = kstat.data.data[group].shape[0]
 
             assert isinstance(pred[group], list)
             assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
 
             assert len(pred[group]) == len(threshold_values)
             assert len(loss[group]) == len(threshold_values)
+            assert len(res[group]) == len(threshold_values)
 
             for pred_val, loss_val, pred_threshold in zip(
                 pred[group], loss[group], threshold_values
@@ -965,12 +1024,15 @@ class TestStatistics(object):
 
                 assert isinstance(pred_val, np.ndarray)
                 assert isinstance(loss_val, np.ndarray)
+                assert isinstance(res_val, np.ndarray)
 
                 assert list(pred_val.shape) == [n_obs, 10]
                 assert list(loss_val.shape) == [n_obs, 10]
+                assert list(res_val.shape) == [n_obs, 10]
 
                 assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
                 assert np.issubdtype(loss_val.dtype, np.floating)
+                assert np.issubdtype(res_val.dtype, np.floating)
 
                 # group 1 and 2 are similar so we expect a prediction
                 # corresponding to the bias
@@ -983,38 +1045,202 @@ class TestStatistics(object):
                     atol=0.3
                 )
 
+        # Case 1c - full data (no Nystrom), no new_obs, extended ouput
+        # default: new_obs=None
+        pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
+            kstat.kfda_predict(
+                t=10, pred_threshold=1/2, extended_output=True
+            )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert isinstance(res, dict)
+        assert isinstance(dist_group1, dict)
+        assert isinstance(dist_group2, dict)
+        assert pred.keys() == kstat.data.data.keys()
+        assert loss.keys() == kstat.data.data.keys()
+        assert res.keys() == kstat.data.data.keys()
+        assert dist_group1.keys() == kstat.data.data.keys()
+        assert dist_group2.keys() == kstat.data.data.keys()
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat.dtype
+
+        for group in kstat.data.data.keys():
+            n_obs = kstat.data.data[group].shape[0]
+
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
+
+            dist_g1 = dist_group1[group]
+            dist_g2 = dist_group2[group]
+
+            assert isinstance(dist_g1, to.Tensor)
+            assert isinstance(dist_g2, to.Tensor)
+            assert dist_g1.shape == (n_obs, 10)
+            assert dist_g2.shape == (n_obs, 10)
+            assert dist_g1.dtype == kstat.dtype
+            assert dist_g2.dtype == kstat.dtype
+
+            assert len(pred[group]) == 1
+            assert len(loss[group]) == 1
+            assert len(res[group]) == 1
+
+            pred_val = pred[group][0]
+            loss_val = loss[group][0]
+            res_val = res[group][0]
+
+            assert isinstance(pred_val, np.ndarray)
+            assert isinstance(loss_val, np.ndarray)
+            assert isinstance(res_val, np.ndarray)
+
+            assert list(pred_val.shape) == [n_obs, 10]
+            assert list(loss_val.shape) == [n_obs, 10]
+            assert list(res_val.shape) == [n_obs, 10]
+
+            assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+            assert np.issubdtype(loss_val.dtype, np.floating)
+            assert np.issubdtype(res_val.dtype, np.floating)
+
+            # group 1 and 2 are similar so we expect 50%-50% prediction
+            count_pred = np.count_nonzero(pred_val == group, axis=0)
+            np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+            # check residuals
+            g1 = list(kstat.data.data.keys())[0]
+            g2 = list(kstat.data.data.keys())[1]
+            exp_res = np.sqrt(
+                (
+                    (pred_val == g1) * dist_g1.numpy()
+                    + (pred_val == g2) * dist_g2.numpy()
+                ) * axis_norm2.numpy()[None, :]
+            )
+            np.testing.assert_allclose(res_val, exp_res)
+
+        # Case 1d - full data (no Nystrom), no new_obs, extended ouput,
+        # with a list of threshold values
+        # default: new_obs=None
+        pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
+            kstat.kfda_predict(
+                t=10, pred_threshold=threshold_values, extended_output=True
+            )
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert isinstance(res, dict)
+        assert isinstance(dist_group1, dict)
+        assert isinstance(dist_group2, dict)
+        assert pred.keys() == kstat.data.data.keys()
+        assert loss.keys() == kstat.data.data.keys()
+        assert res.keys() == kstat.data.data.keys()
+        assert dist_group1.keys() == kstat.data.data.keys()
+        assert dist_group2.keys() == kstat.data.data.keys()
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat.dtype
+
+        for group_ind, group in enumerate(kstat.data.data.keys()):
+            n_obs = kstat.data.data[group].shape[0]
+
+            assert isinstance(pred[group], list)
+            assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
+
+            dist_g1 = dist_group1[group]
+            dist_g2 = dist_group2[group]
+
+            assert isinstance(dist_g1, to.Tensor)
+            assert isinstance(dist_g2, to.Tensor)
+            assert dist_g1.shape == (n_obs, 10)
+            assert dist_g2.shape == (n_obs, 10)
+            assert dist_g1.dtype == kstat.dtype
+            assert dist_g2.dtype == kstat.dtype
+
+            assert len(pred[group]) == len(threshold_values)
+            assert len(loss[group]) == len(threshold_values)
+            assert len(res[group]) == len(threshold_values)
+
+            for pred_val, loss_val, res_val, pred_threshold in zip(
+                pred[group], loss[group], res[group], threshold_values
+            ):
+
+                assert isinstance(pred_val, np.ndarray)
+                assert isinstance(loss_val, np.ndarray)
+                assert isinstance(res_val, np.ndarray)
+
+                assert list(pred_val.shape) == [n_obs, 10]
+                assert list(loss_val.shape) == [n_obs, 10]
+                assert list(res_val.shape) == [n_obs, 10]
+
+                assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+                assert np.issubdtype(loss_val.dtype, np.floating)
+                assert np.issubdtype(res_val.dtype, np.floating)
+
+                # group 1 and 2 are similar so we expect a prediction
+                # corresponding to the bias
+                # (or 1 - bias depending on the group)
+                count_pred = np.count_nonzero(pred_val == group, axis=0)
+                np.testing.assert_allclose(
+                    count_pred / n_obs,
+                    (1 - group_ind) * pred_threshold +
+                    group_ind * (1 - pred_threshold),
+                    atol=0.3
+                )
+
+                # check residuals
+                g1 = list(kstat.data.data.keys())[0]
+                g2 = list(kstat.data.data.keys())[1]
+                exp_res = np.sqrt(
+                    (
+                        (pred_val == g1) * dist_g1.numpy()
+                        + (pred_val == g2) * dist_g2.numpy()
+                    ) * axis_norm2.numpy()[None, :]
+                )
+                np.testing.assert_allclose(res_val, exp_res)
+
         # Case 2a - full data (no Nystrom), providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
-        pred, loss = kstat.kfda_predict(
+        pred, loss, res = kstat.kfda_predict(
             t=10, new_obs=new_obs, pred_threshold=1/2
         )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert list(pred.keys()) == ["new_obs"]
         assert list(loss.keys()) == ["new_obs"]
+        assert list(res.keys()) == ["new_obs"]
 
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
         assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
         count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -1024,35 +1250,43 @@ class TestStatistics(object):
         # biasing prediction (expect only group 2 prediction)
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
-        pred, loss = kstat.kfda_predict(
+        pred, loss, res = kstat.kfda_predict(
             t=10, new_obs=new_obs, pred_threshold=0
         )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert list(pred.keys()) == ["new_obs"]
         assert list(loss.keys()) == ["new_obs"]
+        assert list(res.keys()) == ["new_obs"]
 
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
         assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # we expect only "group 2" prediction
         count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -1062,71 +1296,160 @@ class TestStatistics(object):
         # biasing prediction (expect only group 1 prediction)
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
-        pred, loss = kstat.kfda_predict(
+        pred, loss, res = kstat.kfda_predict(
             t=10, new_obs=new_obs, pred_threshold=1
         )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert list(pred.keys()) == ["new_obs"]
         assert list(loss.keys()) == ["new_obs"]
+        assert list(res.keys()) == ["new_obs"]
 
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
         assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # we expect only "group 1" prediction
         count_pred = np.count_nonzero(pred_val == "c1", axis=0)
         np.testing.assert_allclose(count_pred / n_obs, 1, atol=0)
 
-        # Case 3 - Nystrom approximation, no new_obs
-        # default: new_obs=None
-        pred, loss = kstat_nystrom.kfda_predict(t=10, pred_threshold=1/2)
+        # Case 2d - full data (no Nystrom), providing new_obs, extended ouput
+        new_obs = list(kstat.data.data.values())[0]
+        pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
+            kstat.kfda_predict(
+                t=10, new_obs=new_obs, pred_threshold=1/2, extended_output=True
+            )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
+        assert isinstance(dist_group1, dict)
+        assert isinstance(dist_group2, dict)
+
+        assert list(pred.keys()) == ["new_obs"]
+        assert list(loss.keys()) == ["new_obs"]
+        assert list(res.keys()) == ["new_obs"]
+        assert list(dist_group1.keys()) == ["new_obs"]
+        assert list(dist_group2.keys()) == ["new_obs"]
+
+        group = "new_obs"
+        n_obs = new_obs.shape[0]
+
+        assert isinstance(axis_norm2, to.Tensor)
+        assert axis_norm2.shape == (10,)
+        assert axis_norm2.dtype == kstat.dtype
+
+        assert isinstance(pred[group], list)
+        assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
+
+        dist_g1 = dist_group1[group]
+        dist_g2 = dist_group2[group]
+
+        assert isinstance(dist_g1, to.Tensor)
+        assert isinstance(dist_g2, to.Tensor)
+        assert dist_g1.shape == (n_obs, 10)
+        assert dist_g2.shape == (n_obs, 10)
+        assert dist_g1.dtype == kstat.dtype
+        assert dist_g2.dtype == kstat.dtype
+
+        assert len(pred[group]) == 1
+        assert len(loss[group]) == 1
+        assert len(res[group]) == 1
+
+        pred_val = pred[group][0]
+        loss_val = loss[group][0]
+        res_val = res[group][0]
+
+        assert isinstance(pred_val, np.ndarray)
+        assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
+
+        assert list(pred_val.shape) == [n_obs, 10]
+        assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
+
+        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
+
+        # group 1 and 2 are similar so we expect 50%-50% prediction
+        count_pred = np.count_nonzero(pred_val == "c1", axis=0)
+        np.testing.assert_allclose(count_pred / n_obs, 1/2, atol=0.1)
+
+        # check residuals
+        g1 = list(kstat.data.data.keys())[0]
+        g2 = list(kstat.data.data.keys())[1]
+        exp_res = np.sqrt(
+            (
+                (pred_val == g1) * dist_g1.numpy()
+                + (pred_val == g2) * dist_g2.numpy()
+            ) * axis_norm2.numpy()[None, :]
+        )
+        np.testing.assert_allclose(res_val, exp_res)
+
+        # Case 3 - Nystrom approximation, no new_obs
+        # default: new_obs=None
+        pred, loss, res = kstat_nystrom.kfda_predict(t=10, pred_threshold=1/2)
+
+        assert isinstance(pred, dict)
+        assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert pred.keys() == kstat_nystrom.data.data.keys()
         assert loss.keys() == kstat_nystrom.data.data.keys()
+        assert res.keys() == kstat_nystrom.data.data.keys()
 
-        for group in kstat.data.data.keys():
+        for group in kstat_nystrom.data.data.keys():
             n_obs = kstat_nystrom.data.data[group].shape[0]
 
             assert isinstance(pred[group], list)
             assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
 
             assert len(pred[group]) == 1
             assert len(loss[group]) == 1
+            assert len(res[group]) == 1
 
             pred_val = pred[group][0]
             loss_val = loss[group][0]
+            res_val = res[group][0]
 
             assert isinstance(pred_val, np.ndarray)
             assert isinstance(loss_val, np.ndarray)
+            assert isinstance(res_val, np.ndarray)
 
             assert list(pred_val.shape) == [n_obs, 10]
             assert list(loss_val.shape) == [n_obs, 10]
+            assert list(res_val.shape) == [n_obs, 10]
 
-            assert np.all(np.isin(
-                pred_val, list(kstat_nystrom.data.data.keys())
-            ))
+            assert np.all(np.isin(pred_val, list(kstat_nystrom.data.data.keys())))
             assert np.issubdtype(loss_val.dtype, np.floating)
+            assert np.issubdtype(res_val.dtype, np.floating)
 
             # group 1 and 2 are similar so we expect 50%-50% prediction
             count_pred = np.count_nonzero(pred_val == group, axis=0)
@@ -1135,35 +1458,43 @@ class TestStatistics(object):
         # Case 4 - Nystrom approximation, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
-        pred, loss = kstat_nystrom.kfda_predict(
+        pred, loss, res = kstat_nystrom.kfda_predict(
             t=10, new_obs=new_obs, pred_threshold=1/2
         )
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert list(pred.keys()) == ["new_obs"]
         assert list(loss.keys()) == ["new_obs"]
+        assert list(res.keys()) == ["new_obs"]
 
         group = "new_obs"
         n_obs = new_obs.shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
-        assert np.all(np.isin(pred_val, list(kstat.data.data.keys())))
+        assert np.all(np.isin(pred_val, list(kstat_nystrom.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
         count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -1183,35 +1514,41 @@ class TestStatistics(object):
         )
 
         # no bias in prediction, no new observations
-        pred, loss = kstat_sep.kfda_predict(t=50, pred_threshold=1/2)
+        pred, loss, res = kstat_sep.kfda_predict(t=50, pred_threshold=1/2)
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
+        assert isinstance(res, dict)
         assert pred.keys() == kstat_sep.data.data.keys()
         assert loss.keys() == kstat_sep.data.data.keys()
+        assert res.keys() == kstat_sep.data.data.keys()
 
-        for i, group in enumerate(kstat_sep.data.data.keys()):
+        for group in kstat_sep.data.data.keys():
             n_obs = kstat_sep.data.data[group].shape[0]
 
             assert isinstance(pred[group], list)
             assert isinstance(loss[group], list)
+            assert isinstance(res[group], list)
 
             assert len(pred[group]) == 1
             assert len(loss[group]) == 1
+            assert len(res[group]) == 1
 
             pred_val = pred[group][0]
             loss_val = loss[group][0]
+            res_val = res[group][0]
 
             assert isinstance(pred_val, np.ndarray)
             assert isinstance(loss_val, np.ndarray)
+            assert isinstance(res_val, np.ndarray)
 
             assert list(pred_val.shape) == [n_obs, 50]
             assert list(loss_val.shape) == [n_obs, 50]
+            assert list(res_val.shape) == [n_obs, 50]
 
-            assert np.all(np.isin(
-                pred_val, list(kstat_nystrom.data.data.keys())
-            ))
+            assert np.all(np.isin(pred_val, list(kstat_sep.data.data.keys())))
             assert np.issubdtype(loss_val.dtype, np.floating)
+            assert np.issubdtype(res_val.dtype, np.floating)
 
             # group 1 and 2 are very different so we expect 100%
             # prediction on each group (at least for large truncations)

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -399,36 +399,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=None, pred_threshold=0.5, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert pred.keys() == kt.data.data.keys()
     assert loss.keys() == kt.data.data.keys()
+    assert res.keys() == kt.data.data.keys()
 
     for group in kt.data.data.keys():
         n_obs = kt.data.data[group].shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
         assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
         count_pred = np.count_nonzero(pred_val == group, axis=0)
@@ -443,24 +451,28 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=None, pred_threshold=threshold_values, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert pred.keys() == kt.data.data.keys()
     assert loss.keys() == kt.data.data.keys()
+    assert res.keys() == kt.data.data.keys()
 
     for group_ind, group in enumerate(kt.data.data.keys()):
         n_obs = kt.data.data[group].shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == len(threshold_values)
         assert len(loss[group]) == len(threshold_values)
+        assert len(res[group]) == len(threshold_values)
 
         for pred_val, loss_val, pred_threshold in zip(
             pred[group], loss[group], threshold_values
@@ -468,12 +480,15 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
             assert isinstance(pred_val, np.ndarray)
             assert isinstance(loss_val, np.ndarray)
+            assert isinstance(res_val, np.ndarray)
 
             assert list(pred_val.shape) == [n_obs, 10]
             assert list(loss_val.shape) == [n_obs, 10]
+            assert list(res_val.shape) == [n_obs, 10]
 
             assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
             assert np.issubdtype(loss_val.dtype, np.floating)
+            assert np.issubdtype(res_val.dtype, np.floating)
 
             # group 1 and 2 are similar so we expect a prediction
             # corresponding to the bias
@@ -496,36 +511,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     new_obs = list(kt.data.data.values())[0]
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=new_obs, pred_threshold=0.5, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert list(pred.keys()) == ["new_obs"]
     assert list(loss.keys()) == ["new_obs"]
+    assert list(res.keys()) == ["new_obs"]
 
     group = "new_obs"
     n_obs = new_obs.shape[0]
 
     assert isinstance(pred[group], list)
     assert isinstance(loss[group], list)
+    assert isinstance(res[group], list)
 
     assert len(pred[group]) == 1
     assert len(loss[group]) == 1
+    assert len(res[group]) == 1
 
     pred_val = pred[group][0]
     loss_val = loss[group][0]
+    res_val = res[group][0]
 
     assert isinstance(pred_val, np.ndarray)
     assert isinstance(loss_val, np.ndarray)
+    assert isinstance(res_val, np.ndarray)
 
     assert list(pred_val.shape) == [n_obs, 10]
     assert list(loss_val.shape) == [n_obs, 10]
+    assert list(res_val.shape) == [n_obs, 10]
 
     assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
     assert np.issubdtype(loss_val.dtype, np.floating)
+    assert np.issubdtype(res_val.dtype, np.floating)
 
     # group 1 and 2 are similar so we expect 50%-50% prediction
     count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -542,36 +565,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     new_obs = list(kt.data.data.values())[0]
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=new_obs, pred_threshold=0, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert list(pred.keys()) == ["new_obs"]
     assert list(loss.keys()) == ["new_obs"]
+    assert list(res.keys()) == ["new_obs"]
 
     group = "new_obs"
     n_obs = new_obs.shape[0]
 
     assert isinstance(pred[group], list)
     assert isinstance(loss[group], list)
+    assert isinstance(res[group], list)
 
     assert len(pred[group]) == 1
     assert len(loss[group]) == 1
+    assert len(res[group]) == 1
 
     pred_val = pred[group][0]
     loss_val = loss[group][0]
+    res_val = res[group][0]
 
     assert isinstance(pred_val, np.ndarray)
     assert isinstance(loss_val, np.ndarray)
+    assert isinstance(res_val, np.ndarray)
 
     assert list(pred_val.shape) == [n_obs, 10]
     assert list(loss_val.shape) == [n_obs, 10]
+    assert list(res_val.shape) == [n_obs, 10]
 
     assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
     assert np.issubdtype(loss_val.dtype, np.floating)
+    assert np.issubdtype(res_val.dtype, np.floating)
 
     # we expect only "group 2" prediction
     count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -588,36 +619,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     new_obs = list(kt.data.data.values())[0]
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=new_obs, pred_threshold=1, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert list(pred.keys()) == ["new_obs"]
     assert list(loss.keys()) == ["new_obs"]
+    assert list(res.keys()) == ["new_obs"]
 
     group = "new_obs"
     n_obs = new_obs.shape[0]
 
     assert isinstance(pred[group], list)
     assert isinstance(loss[group], list)
+    assert isinstance(res[group], list)
 
     assert len(pred[group]) == 1
     assert len(loss[group]) == 1
+    assert len(res[group]) == 1
 
     pred_val = pred[group][0]
     loss_val = loss[group][0]
+    res_val = res[group][0]
 
     assert isinstance(pred_val, np.ndarray)
     assert isinstance(loss_val, np.ndarray)
+    assert isinstance(res_val, np.ndarray)
 
     assert list(pred_val.shape) == [n_obs, 10]
     assert list(loss_val.shape) == [n_obs, 10]
+    assert list(res_val.shape) == [n_obs, 10]
 
     assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
     assert np.issubdtype(loss_val.dtype, np.floating)
+    assert np.issubdtype(res_val.dtype, np.floating)
 
     # we expect only "group 1" prediction
     count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -630,38 +669,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest(nystrom=True)
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=None, pred_threshold=0.5, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert pred.keys() == kt.data.data.keys()
     assert loss.keys() == kt.data.data.keys()
+    assert res.keys() == kt.data.data.keys()
 
     for group in kt.data.data.keys():
         n_obs = kt.data.data[group].shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 10]
         assert list(loss_val.shape) == [n_obs, 10]
+        assert list(res_val.shape) == [n_obs, 10]
 
-        assert np.all(np.isin(
-            pred_val, list(kt.data.data.keys())
-        ))
+        assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # group 1 and 2 are similar so we expect 50%-50% prediction
         count_pred = np.count_nonzero(pred_val == group, axis=0)
@@ -677,36 +722,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     new_obs = list(kt.data.data.values())[0]
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=10, new_obs=new_obs, pred_threshold=1/2, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert list(pred.keys()) == ["new_obs"]
     assert list(loss.keys()) == ["new_obs"]
+    assert list(res.keys()) == ["new_obs"]
 
     group = "new_obs"
     n_obs = new_obs.shape[0]
 
     assert isinstance(pred[group], list)
     assert isinstance(loss[group], list)
+    assert isinstance(res[group], list)
 
     assert len(pred[group]) == 1
     assert len(loss[group]) == 1
+    assert len(res[group]) == 1
 
     pred_val = pred[group][0]
     loss_val = loss[group][0]
+    res_val = res[group][0]
 
     assert isinstance(pred_val, np.ndarray)
     assert isinstance(loss_val, np.ndarray)
+    assert isinstance(res_val, np.ndarray)
 
     assert list(pred_val.shape) == [n_obs, 10]
     assert list(loss_val.shape) == [n_obs, 10]
+    assert list(res_val.shape) == [n_obs, 10]
 
-    assert np.all(np.isin(pred_val, list(kt.data_nystrom.data.keys())))
+    assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
     assert np.issubdtype(loss_val.dtype, np.floating)
+    assert np.issubdtype(res_val.dtype, np.floating)
 
     # group 1 and 2 are similar so we expect 50%-50% prediction
     count_pred = np.count_nonzero(pred_val == "c1", axis=0)
@@ -722,38 +775,44 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
     )
 
     # run CV
-    pred, loss = kt.predict(
+    pred, loss, res = kt.predict(
         t=50, new_obs=None, pred_threshold=1/2, verbose=1
     )
 
     # check
     assert isinstance(pred, dict)
     assert isinstance(loss, dict)
+    assert isinstance(res, dict)
     assert pred.keys() == kt.data.data.keys()
     assert loss.keys() == kt.data.data.keys()
+    assert res.keys() == kt.data.data.keys()
 
-    for i, group in enumerate(kt.data.data.keys()):
+    for group in kt.data.data.keys():
         n_obs = kt.data.data[group].shape[0]
 
         assert isinstance(pred[group], list)
         assert isinstance(loss[group], list)
+        assert isinstance(res[group], list)
 
         assert len(pred[group]) == 1
         assert len(loss[group]) == 1
+        assert len(res[group]) == 1
 
         pred_val = pred[group][0]
         loss_val = loss[group][0]
+        res_val = res[group][0]
 
         assert isinstance(pred_val, np.ndarray)
         assert isinstance(loss_val, np.ndarray)
+        assert isinstance(res_val, np.ndarray)
 
         assert list(pred_val.shape) == [n_obs, 50]
         assert list(loss_val.shape) == [n_obs, 50]
+        assert list(res_val.shape) == [n_obs, 50]
 
-        assert np.all(np.isin(
-            pred_val, list(kt.data.data.keys())
-        ))
+        assert np.all(np.isin(pred_val, list(kt.data.data.keys())))
         assert np.issubdtype(loss_val.dtype, np.floating)
+        assert np.issubdtype(res_val.dtype, np.floating)
 
         # group 1 and 2 are very different so we expect 100%
         # prediction on each group (at least for large truncations)
@@ -771,7 +830,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     # create ktest objects
     kt = dummy_ktest()
     # run CV
-    accuracy, true_pos, true_neg = kt.cv(
+    accuracy, true_pos, true_neg, residuals = kt.cv(
         t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
         random_state=None, verbose=1
     )
@@ -785,23 +844,30 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     assert isinstance(accuracy, list)
     assert isinstance(true_pos, list)
     assert isinstance(true_neg, list)
+    assert isinstance(residuals, list)
 
     assert len(accuracy) == 1
     assert len(true_pos) == 1
     assert len(true_neg) == 1
+    assert len(residuals) == 1
 
-    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
-        accuracy, true_pos, true_neg
+    for accuracy_tab, true_pos_tab, true_neg_tab, res_tab in zip(
+        accuracy, true_pos, true_neg, residuals
     ):
         # type
         assert isinstance(accuracy_tab, np.ndarray)
         assert isinstance(true_pos_tab, np.ndarray)
         assert isinstance(true_neg_tab, np.ndarray)
+        assert isinstance(res_tab, np.ndarray)
 
         # dimension
         assert accuracy_tab.shape == (50,)
         assert true_pos_tab.shape == (50,)
         assert true_neg_tab.shape == (50,)
+        assert res_tab.shape == (50,)
+
+        # residuals
+        assert np.issubdtype(res_tab.dtype, np.floating)
 
         # value (expect 50%-50% accuracy)
         np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
@@ -813,7 +879,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     # create ktest objects
     kt = dummy_ktest()
     # run CV
-    accuracy, true_pos, true_neg = kt.cv(
+    accuracy, true_pos, true_neg, residuals = kt.cv(
         t=50, pred_threshold=1, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
@@ -826,23 +892,30 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     assert isinstance(accuracy, list)
     assert isinstance(true_pos, list)
     assert isinstance(true_neg, list)
+    assert isinstance(residuals, list)
 
     assert len(accuracy) == 1
     assert len(true_pos) == 1
     assert len(true_neg) == 1
+    assert len(residuals) == 1
 
-    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
-        accuracy, true_pos, true_neg
+    for accuracy_tab, true_pos_tab, true_neg_tab, res_tab in zip(
+        accuracy, true_pos, true_neg, residuals
     ):
         # type
         assert isinstance(accuracy_tab, np.ndarray)
         assert isinstance(true_pos_tab, np.ndarray)
         assert isinstance(true_neg_tab, np.ndarray)
+        assert isinstance(res_tab, np.ndarray)
 
         # dimension
         assert accuracy_tab.shape == (50,)
         assert true_pos_tab.shape == (50,)
         assert true_neg_tab.shape == (50,)
+        assert res_tab.shape == (50,)
+
+        # residuals
+        assert np.issubdtype(res_tab.dtype, np.floating)
 
         # value (expect 50%-50% accuracy but biased sens/spec)
         np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
@@ -854,7 +927,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     # create ktest objects
     kt = dummy_ktest()
     # run CV
-    accuracy, true_pos, true_neg = kt.cv(
+    accuracy, true_pos, true_neg, residuals = kt.cv(
         t=50, pred_threshold=0, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
@@ -863,23 +936,30 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     assert isinstance(accuracy, list)
     assert isinstance(true_pos, list)
     assert isinstance(true_neg, list)
+    assert isinstance(residuals, list)
 
     assert len(accuracy) == 1
     assert len(true_pos) == 1
     assert len(true_neg) == 1
+    assert len(residuals) == 1
 
-    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
-        accuracy, true_pos, true_neg
+    for accuracy_tab, true_pos_tab, true_neg_tab, res_tab in zip(
+        accuracy, true_pos, true_neg, residuals
     ):
         # type
         assert isinstance(accuracy_tab, np.ndarray)
         assert isinstance(true_pos_tab, np.ndarray)
         assert isinstance(true_neg_tab, np.ndarray)
+        assert isinstance(res_tab, np.ndarray)
 
         # dimension
         assert accuracy_tab.shape == (50,)
         assert true_pos_tab.shape == (50,)
         assert true_neg_tab.shape == (50,)
+        assert res_tab.shape == (50,)
+
+        # residuals
+        assert np.issubdtype(res_tab.dtype, np.floating)
 
         # value (expect 50%-50% accuracy but biased sens/spec)
         np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
@@ -891,7 +971,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
     # run CV
     threshold_values = np.linspace(0, 1, 11)
-    accuracy, true_pos, true_neg = kt.cv(
+    accuracy, true_pos, true_neg, residuals = kt.cv(
         t=50, pred_threshold=threshold_values, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
@@ -899,23 +979,32 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     assert isinstance(accuracy, list)
     assert isinstance(true_pos, list)
     assert isinstance(true_neg, list)
+    assert isinstance(residuals, list)
 
     assert len(accuracy) == len(threshold_values)
     assert len(true_pos) == len(threshold_values)
     assert len(true_neg) == len(threshold_values)
+    assert len(residuals) == len(threshold_values)
 
-    for accuracy_tab, true_pos_tab, true_neg_tab, pred_threshold in zip(
-        accuracy, true_pos, true_neg, threshold_values
+    for (
+        accuracy_tab, true_pos_tab, true_neg_tab, res_tab, pred_threshold
+    ) in zip(
+        accuracy, true_pos, true_neg, residuals, threshold_values
     ):
         # type
         assert isinstance(accuracy_tab, np.ndarray)
         assert isinstance(true_pos_tab, np.ndarray)
         assert isinstance(true_neg_tab, np.ndarray)
+        assert isinstance(res_tab, np.ndarray)
 
         # dimension
         assert accuracy_tab.shape == (50,)
         assert true_pos_tab.shape == (50,)
         assert true_neg_tab.shape == (50,)
+        assert res_tab.shape == (50,)
+
+        # residuals
+        assert np.issubdtype(res_tab.dtype, np.floating)
 
         # value (expect 50%-50% accuracy)
         np.testing.assert_allclose(accuracy_tab, 1/2, atol=0.1)
@@ -930,7 +1019,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
         nystrom=True
     )
     # run CV
-    accuracy, true_pos, true_neg = kt.cv(
+    accuracy, true_pos, true_neg, residuals = kt.cv(
         t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
         random_state=None, verbose=1
     )
@@ -939,23 +1028,30 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     assert isinstance(accuracy, list)
     assert isinstance(true_pos, list)
     assert isinstance(true_neg, list)
+    assert isinstance(residuals, list)
 
     assert len(accuracy) == 1
     assert len(true_pos) == 1
     assert len(true_neg) == 1
+    assert len(residuals) == 1
 
-    for accuracy_tab, true_pos_tab, true_neg_tab in zip(
-        accuracy, true_pos, true_neg
+    for accuracy_tab, true_pos_tab, true_neg_tab, res_tab in zip(
+        accuracy, true_pos, true_neg, residuals
     ):
         # type
         assert isinstance(accuracy_tab, np.ndarray)
         assert isinstance(true_pos_tab, np.ndarray)
         assert isinstance(true_neg_tab, np.ndarray)
+        assert isinstance(res_tab, np.ndarray)
 
         # dimension
         assert accuracy_tab.shape == (50,)
         assert true_pos_tab.shape == (50,)
         assert true_neg_tab.shape == (50,)
+        assert res_tab.shape == (50,)
+
+        # residuals
+        assert np.issubdtype(res_tab.dtype, np.floating)
 
         # value (expect almost 100% accuracy for non-small truncations)
         np.testing.assert_allclose(accuracy_tab[10:], 1, atol=0.1)


### PR DESCRIPTION
Implementing kFDA residual computation:

* b5631a5 bump package version (implement kFDA residual computation)
* 1e3694c toy example script for cross-validation
* 8be8d29 implement residual computation in prediction and cross-validation for Ktest object
* 244ff42 implement kFDA residual computations