### PR TITLE
Fix some parameter/variable/attribute/function names to simplify code understanding or to avoid confusion

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ktest"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -595,7 +595,7 @@ class Statistics(object):
             pkm = mv(Pbi, mv(Kx, omega))
         return pkm
 
-    def compute_kfda(self):
+    def compute_kfda_stat(self):
         """
         Computes the kFDA truncated statistic of [Harchaoui 2009].
 
@@ -902,7 +902,7 @@ class Statistics(object):
 
         # get kFDA stat Value
         if stat is None:
-            stat, _ = self.compute_kfda()
+            stat, _ = self.compute_kfda_stat()
 
         # compute kfda projection for training data
         proj, _ = self.compute_projections(
@@ -969,7 +969,7 @@ class Statistics(object):
         """
         # get kFDA stat Value
         if stat is None:
-            stat, _ = self.compute_kfda()
+            stat, _ = self.compute_kfda_stat()
 
         # Maximal truncation identification:
         n_trunc = min(n_trunc, len(self.sp))

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -791,14 +791,14 @@ class Statistics(object):
         Returns
         -------
 
-        proj_kfda : pandas.DataFrame
+        proj : pandas.DataFrame
             Projections associated with every observation (rows) on every
             eigendirection (columns).
 
-        proj_kpca : pandas.DataFrame
+        proj_contrib : pandas.DataFrame
             Contributions of each eigendirection (columns) to projections
-            associated with every observation (rows). 'proj_kfda' contains the
-            cumulated sum of the values in 'proj_kpca'.
+            associated with every observation (rows). 'proj' contains the
+            cumulated sum of the values in 'proj_contrib'.
 
         """
         # diagonalize centered Gram matrix if needed
@@ -836,8 +836,8 @@ class Statistics(object):
         else:
             proj_list = [proj[:n1], proj[n1:]]
         # init output
-        proj_kfda = {}
-        proj_kpca = {}
+        proj = {}
+        proj_contrib = {}
         # group index (create a new one for new_obs if needed)
         if new_obs is not None:
             index_dict = {"new_obs": pd.Index(range(new_obs.shape[0]))}
@@ -845,18 +845,18 @@ class Statistics(object):
             index_dict = self.data.index
         # iterate through groups
         for i, (name, ind) in enumerate(index_dict.items()):
-            proj_kpca[name] = pd.DataFrame(
+            proj_contrib[name] = pd.DataFrame(
                 proj_list[i], index=ind,
                 columns=[str(t) for t in range(1, n_trunc + 1)]
             )
-            proj_kfda[name] = pd.DataFrame(
+            proj[name] = pd.DataFrame(
                 proj_list[i].cumsum(axis=1), index=ind,
                 columns=[str(t) for t in range(1, n_trunc + 1)]
             )
-            proj_kfda[name] /= np.sqrt(
+            proj[name] /= np.sqrt(
                 n ** 3 * stat.values[:n_trunc] / (n1 * n2)
             )
-        return proj_kfda, proj_kpca
+        return proj, proj_contrib
 
     def kfda_loss(self, n_trunc=100, new_obs=None, stat=None):
         """
@@ -905,21 +905,21 @@ class Statistics(object):
             stat, _ = self.compute_kfda()
 
         # compute kfda projection for training data
-        proj_kfda, _ = self.compute_projections(
+        proj, _ = self.compute_projections(
             stat, n_trunc, center=False, new_obs=None
         )
 
         # compute mean embedding for training data (in the two groups)
         mean_embed = []
-        for group in proj_kfda.keys():
-            mean_embed.append(proj_kfda[group].mean(axis=0))
+        for group in proj.keys():
+            mean_embed.append(proj[group].mean(axis=0))
         mean_embed = pd.DataFrame(mean_embed)
         # cast back to torch object
         mean_embed = to.from_numpy(mean_embed.values)
 
         # if new observation, compute corresponding projection
         if new_obs is not None:
-            proj_kfda, _ = self.compute_projections(
+            proj, _ = self.compute_projections(
                 stat, n_trunc, center=False, new_obs=new_obs
             )
 
@@ -929,7 +929,7 @@ class Statistics(object):
 
         # compute loss function compartments for each observation set
         # iterate through group (or new obs)
-        for i, (group, proj_tab) in enumerate(proj_kfda.items()):
+        for i, (group, proj_tab) in enumerate(proj.items()):
 
             # cast back to torch object
             proj_tab = to.from_numpy(proj_tab.values)

--- a/python/src/ktest/kernel_statistics.py
+++ b/python/src/ktest/kernel_statistics.py
@@ -671,7 +671,7 @@ class Statistics(object):
         self.sp, self.ev = self.diagonalize_centered_gram()
 
         # Maximal truncation identification:
-        t = len(self.sp)
+        n_trunc = len(self.sp)
 
         # Calculating statistic for every truncation:
         pkm = self.compute_pkm()
@@ -680,12 +680,12 @@ class Statistics(object):
 
         # Calculating contributions of every truncation:
         kfda_contributions = ((n1 * n2) / (self.data.ntot ** exposant
-                                           * self.sp[:t] ** exposant)
-                              * mv(self.ev.T[:t], pkm) ** 2).numpy()
+                                           * self.sp[:n_trunc] ** exposant)
+                              * mv(self.ev.T[:n_trunc], pkm) ** 2).numpy()
         # Sum of contributions produces the kFDA statistic:
         kfda = kfda_contributions.cumsum(axis=0)
 
-        trunc = range(1, t+1)  # truncations
+        trunc = range(1, n_trunc + 1)  # truncations
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -722,7 +722,7 @@ class Statistics(object):
             mmd = dot(mv(K, m), m) ** 2
         return mmd.item()
 
-    def compute_upk(self, t, new_obs=None):
+    def compute_upk(self, n_trunc, new_obs=None):
         """
         epk is an alias for the product ePK that appears when projecting the
         data on the discriminant axis. This functions computes the
@@ -735,7 +735,7 @@ class Statistics(object):
 
         Parameters
         ----------
-            t : int
+            n_trunc: int
                 Maximal truncation.
             new_obs : torch.tensor, optional
                 Unused by default. If not None, then the Gram matrix between
@@ -751,15 +751,15 @@ class Statistics(object):
             Lz12 = diag(self.sp_anchors**-(1/2))
             epk = 1 / self.data_ny.ntot**(1/2) * \
                 multi_dot([
-                    self.ev.T[:t], Lz12, self.ev_anchors.T, Kzx
+                    self.ev.T[:n_trunc], Lz12, self.ev_anchors.T, Kzx
                 ]).T
         else:
             Pbi = self.compute_centering_matrix()
             Kx = self.compute_gram(new_obs=new_obs)
-            epk = multi_dot([self.ev.T[:t], Pbi, Kx]).T
+            epk = multi_dot([self.ev.T[:n_trunc], Pbi, Kx]).T
         return epk
 
-    def compute_projections(self, stat, t=100, center=True, new_obs=None):
+    def compute_projections(self, stat, n_trunc=100, center=True, new_obs=None):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -777,7 +777,7 @@ class Statistics(object):
             kFDA statistics (same as the attribute `kfda_statistic` of class
             Ktest). Required for normalization.
 
-        t : int, optional
+        n_trunc: int, optional
             Maximal truncation, the default is 100.
 
         center : bool, optional
@@ -805,10 +805,10 @@ class Statistics(object):
         if self.sp is None and self.ev is None:
             self.sp, self.ev = self.diagonalize_centered_gram()
         # fix truncation if needed
-        t = min(t, len(self.sp))
+        n_trunc = min(n_trunc, len(self.sp))
         # compute intermediate quantities
         pkm = self.compute_pkm()
-        upk = self.compute_upk(t, new_obs=new_obs)
+        upk = self.compute_upk(n_trunc, new_obs=new_obs)
         # number of observations in training data
         n1, n2 = self.data.nobs.values()
         n = self.data.ntot
@@ -823,11 +823,11 @@ class Statistics(object):
             centering_mat = eye(n_obs, dtype=self.dtype) \
                 - ones((n_obs, n_obs), dtype=self.dtype) / n_obs
             # project
-            proj = (self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
+            proj = (self.sp[:n_trunc]**(-2) * mv(self.ev.T[:n_trunc], pkm)
                     * matmul(centering_mat, upk)).numpy()
         else:
             # project
-            proj = (self.sp[:t]**(-2) * mv(self.ev.T[:t], pkm)
+            proj = (self.sp[:n_trunc]**(-2) * mv(self.ev.T[:n_trunc], pkm)
                     * upk).numpy()
         # post-processing
         # (manage training data vs new obsercations differently)
@@ -847,18 +847,18 @@ class Statistics(object):
         for i, (name, ind) in enumerate(index_dict.items()):
             proj_kpca[name] = pd.DataFrame(
                 proj_list[i], index=ind,
-                columns=[str(t) for t in range(1, t+1)]
+                columns=[str(t) for t in range(1, n_trunc + 1)]
             )
             proj_kfda[name] = pd.DataFrame(
                 proj_list[i].cumsum(axis=1), index=ind,
-                columns=[str(t) for t in range(1, t+1)]
+                columns=[str(t) for t in range(1, n_trunc + 1)]
             )
             proj_kfda[name] /= np.sqrt(
-                n ** 3 * stat.values[:t] / (n1 * n2)
+                n ** 3 * stat.values[:n_trunc] / (n1 * n2)
             )
         return proj_kfda, proj_kpca
 
-    def kfda_loss(self, t=100, new_obs=None, stat=None):
+    def kfda_loss(self, n_trunc=100, new_obs=None, stat=None):
         """
         Compute the two compartments (one for each group) of the kFDA loss
         function associated to the prediction for each observations (either in
@@ -871,7 +871,7 @@ class Statistics(object):
         Parameters
         ----------
 
-        t: int, optional
+        n_trunc: int, optional
             Maximal truncation, the default is 100.
 
         new_obs: torch.tensor, optional
@@ -906,7 +906,7 @@ class Statistics(object):
 
         # compute kfda projection for training data
         proj_kfda, _ = self.compute_projections(
-            stat, t, center=False, new_obs=None
+            stat, n_trunc, center=False, new_obs=None
         )
 
         # compute mean embedding for training data (in the two groups)
@@ -920,7 +920,7 @@ class Statistics(object):
         # if new observation, compute corresponding projection
         if new_obs is not None:
             proj_kfda, _ = self.compute_projections(
-                stat, t, center=False, new_obs=new_obs
+                stat, n_trunc, center=False, new_obs=new_obs
             )
 
         # init output
@@ -944,14 +944,14 @@ class Statistics(object):
         # output
         return distance_group1, distance_group2
 
-    def kfda_axis_norm2(self, t=100, stat=None):
+    def kfda_axis_norm2(self, n_trunc=100, stat=None):
         """
         Computes the kFDA discriminant axis squared norm.
 
         Parameters
         ----------
 
-        t: int, optional
+        n_trunc: int, optional
             Maximal truncation, the default is 100.
 
         stat : Pandas.Series, optional
@@ -972,7 +972,7 @@ class Statistics(object):
             stat, _ = self.compute_kfda()
 
         # Maximal truncation identification:
-        t = min(t, len(self.sp))
+        n_trunc = min(n_trunc, len(self.sp))
 
         # Calculating statistic for every truncation:
         pkm = self.compute_pkm()
@@ -983,14 +983,14 @@ class Statistics(object):
         # Calculating discriminant axis squared norm for every truncation:
         kfda_axis_norm2 = \
             (n1 * n2) / (self.data.ntot ** exposant_n
-                         * self.sp[:t] ** exposant_sp
-                         * to.from_numpy(stat.values[:t])) \
-            * mv(self.ev.T[:t], pkm) ** 2
+                         * self.sp[:n_trunc] ** exposant_sp
+                         * to.from_numpy(stat.values[:n_trunc])) \
+            * mv(self.ev.T[:n_trunc], pkm) ** 2
         # output
         return kfda_axis_norm2
 
     def kfda_predict(
-        self, t=100, new_obs=None, pred_threshold=0.5, stat=None,
+        self, n_trunc=100, new_obs=None, pred_threshold=0.5, stat=None,
         extended_output=False
     ):
         """
@@ -1001,7 +1001,7 @@ class Statistics(object):
         Parameters
         ----------
 
-        t : int, optional
+        n_trunc: int, optional
             Maximal truncation, the default is 100.
 
         new_obs: torch.tensor, optional
@@ -1084,10 +1084,10 @@ class Statistics(object):
                 raise ValueError(msg)
 
         # compute loss function associated to kFDA prediction
-        distance_group1, distance_group2 = self.kfda_loss(t, new_obs, stat)
+        distance_group1, distance_group2 = self.kfda_loss(n_trunc, new_obs, stat)
 
         # compute discriminant axis squared norm
-        axis_norm2 = self.kfda_axis_norm2(t, stat)
+        axis_norm2 = self.kfda_axis_norm2(n_trunc, stat)
 
         # init output (dictionaries)
         pred = {}     # prediction

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -480,7 +480,7 @@ class Ktest(Statistics):
                     "Possible values : 'kfda','mmd'"
                 )
 
-    def project(self, t=100, center=True, new_obs=None, verbose=1):
+    def project(self, n_trunc=100, center=True, new_obs=None, verbose=1):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -490,7 +490,7 @@ class Ktest(Statistics):
 
         Parameters
         ----------
-        t : int, optional
+        n_trunc : int, optional
             Maximal truncation for projections calculation, the default is 100.
 
         center : bool, optional
@@ -550,7 +550,7 @@ class Ktest(Statistics):
 
             # compute projections
             kfda_proj, kfda_proj_contrib = self.kstat.compute_projections(
-                self.kfda_statistic, t=t, center=center, new_obs=new_obs
+                self.kfda_statistic, n_trunc=n_trunc, center=center, new_obs=new_obs
             )
 
             # record projections only when projecting training data
@@ -560,7 +560,7 @@ class Ktest(Statistics):
             # output
             return kfda_proj, kfda_proj_contrib
 
-    def predict(self, t=100, new_obs=None, pred_threshold=0.5, verbose=1):
+    def predict(self, n_trunc=100, new_obs=None, pred_threshold=0.5, verbose=1):
         """
         Compute prediction for each observations according to kFDA and with
         increasing truncation values, i.e. assign each observations to one of
@@ -569,7 +569,7 @@ class Ktest(Statistics):
         Parameters
         ----------
 
-        t : int, optional
+        n_trunc : int, optional
             Maximal truncation, the default is 100.
 
         new_obs: array-like, pandas.DataFrame or torch.Tensor or numpy.array,
@@ -650,7 +650,7 @@ class Ktest(Statistics):
 
             # compute prediction
             kfda_pred, kfda_loss, kfda_res = self.kstat.kfda_predict(
-                t=t, new_obs=new_obs, pred_threshold=pred_threshold,
+                n_trunc=n_trunc, new_obs=new_obs, pred_threshold=pred_threshold,
                 stat=self.kfda_statistic
             )
 
@@ -658,7 +658,7 @@ class Ktest(Statistics):
             return kfda_pred, kfda_loss, kfda_res
 
     def cv(
-        self, t=100, pred_threshold=0.5, n_fold=5, n_repeat=1, ref=None,
+        self, n_trunc=100, pred_threshold=0.5, n_fold=5, n_repeat=1, ref=None,
         random_state=None, verbose=1
     ):
         """
@@ -669,7 +669,7 @@ class Ktest(Statistics):
         Parameters
         ----------
 
-        t : int, optional
+        n_trunc : int, optional
             Maximal truncation, the default is 100.
 
         pred_threshold : float or Iterable, optional
@@ -797,7 +797,7 @@ class Ktest(Statistics):
 
                 # compute prediction
                 kfda_pred, kfda_loss, kfda_res = kstat_train.kfda_predict(
-                    t=t,
+                    n_trunc=n_trunc,
                     new_obs=to.from_numpy(
                         self.dataset.iloc[test_index].to_numpy()
                     ),
@@ -917,7 +917,7 @@ class Ktest(Statistics):
             t_max = t
         if not self.kfda_proj or \
                 str(t) not in self.kfda_proj[self.sample_names[0]]:
-            self.project(t=t_max)
+            self.project(n_trunc=t_max)
 
         if colors is None:
             colors = {
@@ -1010,7 +1010,7 @@ class Ktest(Statistics):
             t_max = max_t_xy
         if not self.kfda_proj or \
                 str(max_t_xy) not in self.kfda_proj[self.sample_names[0]]:
-            self.project(t=t_max)
+            self.project(n_trunc=t_max)
         if proj_xy[0] == 'kfda' and proj_xy[1] == 'kfda_contrib':
             dict_proj_x = self.kfda_proj
             dict_proj_y = self.kfda_proj_contrib

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -126,16 +126,12 @@ class Ktest(Statistics):
             None if not computed. Otherwise, stores the computed kFDA
             statistics. Indices correspond to truncations.
 
-        kfda_pval_asymp : Pandas.Series or None
+        pval : Pandas.Series or None
             None if not computed. Otherwise, stores the p-values associated
             with the kFDA statistic (stored in 'stat'), obtained
             from the asymptotic distribution (chi-square with T degree of
-            freedom). Indices correspond to truncations.
-
-        kfda_pval_perm  : Pandas.Series or None
-            None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'stat'), obtained
-            with a permutation approach. Indices correspond to truncations.
+            freedom) or with a permutation approach (if requested).
+            Indices correspond to truncations.
 
         stat_contrib : Pandas.Series or None
             None if not computed. Otherwise, stores the unidirectional
@@ -144,13 +140,28 @@ class Ktest(Statistics):
             of the values in `kfda_contributions`. Indices correspond to
             truncations.
 
+        kfda_pval_asymp : Pandas.Series or None
+            None if not computed. Otherwise, stores the p-values associated
+            with the kFDA statistic (stored in 'stat'), obtained
+            from the asymptotic distribution (chi-square with T degree of
+            freedom). Indices correspond to truncations.
+            Note for dev: kept for legacy purpose only.
+
+        kfda_pval_perm  : Pandas.Series or None
+            None if not computed. Otherwise, stores the p-values associated
+            with the kFDA statistic (stored in 'stat'), obtained
+            with a permutation approach. Indices correspond to truncations.
+            Note for dev: kept for legacy purpose only.
+
         mmd_statistic : float or None
             None if not computed. Otherwise, stores the MMD test statistics.
+            Note for dev: kept for legacy purpose only.
 
         mmd_pval_perm : float or None
             None if not computed. Otherwise, stores the p-values
             associated with each MMD statistic (only the permutation approach
             is considered for MMD).
+            Note for dev: kept for legacy purpose only.
 
         proj : pandas.DataFrame
             Projections of the embeddings on the discriminant axis
@@ -247,6 +258,7 @@ class Ktest(Statistics):
             ### Output statistics ###
             ## kFDA statistic
             self.stat = None
+            self.pval = None
             self.kfda_pval_asymp = None
             self.kfda_pval_perm = None
             self.stat_contrib = None
@@ -460,11 +472,13 @@ class Ktest(Statistics):
                     self.compute_test_statistic(verbose=verbose)
                 if not permutation:
                     self.kfda_pval_asymp = self.compute_pvalue(verbose=verbose)
+                    self.pval = self.kfda_pval_asymp
                 else:
                     self.kfda_pval_perm = self.compute_pvalue(
                         permutation=permutation, n_permutations=n_permutations,
                         verbose=verbose
                     )
+                    self.pval = self.kfda_pval_perm
             elif stat == 'mmd':
                 if verbose > 0:
                     print('- Computing MMD statistic')
@@ -474,6 +488,7 @@ class Ktest(Statistics):
                 self.mmd_pval_perm = self.compute_pvalue(
                     stat=stat, verbose=verbose, n_permutations=n_permutations
                 )
+                self.pval = self.mmd_pval_perm
             else:
                 raise ValueError(
                     f"Statistic '{stat}' not recognized. " +

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -480,7 +480,7 @@ class Ktest(Statistics):
                     "Possible values : 'kfda','mmd'"
                 )
 
-    def project(self, n_trunc=100, center=True, new_obs=None, verbose=1):
+    def get_projections(self, n_trunc=100, center=True, new_obs=None, verbose=1):
         """
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
@@ -917,7 +917,7 @@ class Ktest(Statistics):
             t_max = t
         if not self.proj or \
                 str(t) not in self.proj[self.sample_names[0]]:
-            self.project(n_trunc=t_max)
+            self.get_projections(n_trunc=t_max)
 
         if colors is None:
             colors = {
@@ -1010,7 +1010,7 @@ class Ktest(Statistics):
             t_max = max_t_xy
         if not self.proj or \
                 str(max_t_xy) not in self.proj[self.sample_names[0]]:
-            self.project(n_trunc=t_max)
+            self.get_projections(n_trunc=t_max)
         if proj_xy[0] == 'kfda' and proj_xy[1] == 'kfda_contrib':
             dict_proj_x = self.proj
             dict_proj_y = self.proj_contrib

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -152,17 +152,17 @@ class Ktest(Statistics):
             associated with each MMD statistic (only the permutation approach
             is considered for MMD).
 
-        kfda_proj : pandas.DataFrame
+        proj : pandas.DataFrame
             Projections of the embeddings on the discriminant axis
             corresponding to the KFDA statistic, associated with every
             observation (rows) on every eigendirection (columns).
 
-        kfda_proj_contrib : pandas.DataFrame
+        proj_contrib : pandas.DataFrame
             Contributions of each eigendirection (columns) to projections of
             the embeddings on the discriminant axis corresponding to the
             KFDA statistic, associated with every observation (rows).
-            'kfda_proj' contains the cumulated sum of the values in
-            'kfda_proj_contrib'.
+            'proj' contains the cumulated sum of the values in
+            'proj_contrib'.
 
         rnd_gen : int, numpy.random.Generator instance,
                 numpy.random.RandomState instance or None
@@ -256,8 +256,8 @@ class Ktest(Statistics):
             self.mmd_pval_perm = None
 
             ### Projections:
-            self.kfda_proj = {}
-            self.kfda_proj_contrib = {}
+            self.proj = {}
+            self.proj_contrib = {}
 
     def __str__(self):
         s = "An object of class Ktest."
@@ -485,7 +485,7 @@ class Ktest(Statistics):
         Computes the vector of projection of the embeddings on the discriminant
         axis corresponding to the KFDA statistic for every truncation up to t.
         Assigns the values of projections and the contributions of every
-        eigendirection to attributes 'kfda_proj' and 'kfda_proj_contrib'
+        eigendirection to attributes 'proj' and 'proj_contrib'
         respectively.
 
         Parameters
@@ -549,16 +549,16 @@ class Ktest(Statistics):
                     new_obs = to.from_numpy(new_obs)
 
             # compute projections
-            kfda_proj, kfda_proj_contrib = self.kstat.compute_projections(
+            proj, proj_contrib = self.kstat.compute_projections(
                 self.kfda_statistic, n_trunc=n_trunc, center=center, new_obs=new_obs
             )
 
             # record projections only when projecting training data
-            self.kfda_proj = kfda_proj
-            self.kfda_proj_contrib = kfda_proj_contrib
+            self.proj = proj
+            self.proj_contrib = proj_contrib
 
             # output
-            return kfda_proj, kfda_proj_contrib
+            return proj, proj_contrib
 
     def predict(self, n_trunc=100, new_obs=None, pred_threshold=0.5, verbose=1):
         """
@@ -915,8 +915,8 @@ class Ktest(Statistics):
             )
         if t > t_max:
             t_max = t
-        if not self.kfda_proj or \
-                str(t) not in self.kfda_proj[self.sample_names[0]]:
+        if not self.proj or \
+                str(t) not in self.proj[self.sample_names[0]]:
             self.project(n_trunc=t_max)
 
         if colors is None:
@@ -927,7 +927,7 @@ class Ktest(Statistics):
 
         rc('font', **{'family': font_family})
         fig, ax = plt.subplots(ncols=1, figsize=(12, 6))
-        for name, df_proj in self.kfda_proj.items():
+        for name, df_proj in self.proj.items():
             dfxy = df_proj[str(t)]
             min_proj, max_proj = dfxy.min(), dfxy.max()
             min_scaled = min_proj - 0.1 * (max_proj - min_proj)
@@ -1008,16 +1008,16 @@ class Ktest(Statistics):
             )
         if max_t_xy > t_max:
             t_max = max_t_xy
-        if not self.kfda_proj or \
-                str(max_t_xy) not in self.kfda_proj[self.sample_names[0]]:
+        if not self.proj or \
+                str(max_t_xy) not in self.proj[self.sample_names[0]]:
             self.project(n_trunc=t_max)
         if proj_xy[0] == 'kfda' and proj_xy[1] == 'kfda_contrib':
-            dict_proj_x = self.kfda_proj
-            dict_proj_y = self.kfda_proj_contrib
+            dict_proj_x = self.proj
+            dict_proj_y = self.proj_contrib
             t_xy = [t_x, t_x + 1]
         elif proj_xy[0] == 'kfda_contrib' and proj_xy[1] == 'kfda_contrib':
-            dict_proj_x = self.kfda_proj_contrib
-            dict_proj_y = self.kfda_proj_contrib
+            dict_proj_x = self.proj_contrib
+            dict_proj_y = self.proj_contrib
             t_xy = [t_x, t_y]
         else:
             err_txt = "Possible values for 'proj_xy': "

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -122,25 +122,25 @@ class Ktest(Statistics):
             the Nystrom dataset, see the documentation of the class Data
             for more details.
 
-        kfda_statistic : Pandas.Series or None
+        stat : Pandas.Series or None
             None if not computed. Otherwise, stores the computed kFDA
             statistics. Indices correspond to truncations.
 
         kfda_pval_asymp : Pandas.Series or None
             None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'kfda_statistic'), obtained
+            with the kFDA statistic (stored in 'stat'), obtained
             from the asymptotic distribution (chi-square with T degree of
             freedom). Indices correspond to truncations.
 
         kfda_pval_perm  : Pandas.Series or None
             None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'kfda_statistic'), obtained
+            with the kFDA statistic (stored in 'stat'), obtained
             with a permutation approach. Indices correspond to truncations.
 
-        kfda_statistic_contrib : Pandas.Series or None
+        stat_contrib : Pandas.Series or None
             None if not computed. Otherwise, stores the unidirectional
             statistic associated with each eigendirection of the within-group
-            covariance operator. `kfda_statistic` contains the cumulated sum
+            covariance operator. `stat` contains the cumulated sum
             of the values in `kfda_contributions`. Indices correspond to
             truncations.
 
@@ -246,10 +246,10 @@ class Ktest(Statistics):
 
             ### Output statistics ###
             ## kFDA statistic
-            self.kfda_statistic = None
+            self.stat = None
             self.kfda_pval_asymp = None
             self.kfda_pval_perm = None
-            self.kfda_statistic_contrib = None
+            self.stat_contrib = None
 
             ## MMD statistic
             self.mmd_statistic = None
@@ -273,11 +273,11 @@ class Ktest(Statistics):
         s += '\nMMD:\n'
         s += f'{mmd_s}' if self.mmd_statistic is not None else ncs
         s += '\nkFDA:'
-        if self.kfda_statistic is None:
+        if self.stat is None:
             s += '\n' + ncs
         else:
-            for t in range(min(len(self.kfda_statistic), 5)):
-                s += f'\nTruncation {t+1}: {self.kfda_statistic.iloc[t]}. '
+            for t in range(min(len(self.stat), 5)):
+                s += f'\nTruncation {t+1}: {self.stat.iloc[t]}. '
                 s += 'P-value:\n'
                 s += 'asymptotic: '
                 s += (f'{self.kfda_pval_asymp.iloc[t]}'
@@ -369,16 +369,16 @@ class Ktest(Statistics):
         if stat == 'kfda' and not permutation:
             if verbose > 0:
                 print('- Computing asymptotic p-values')
-            pval = chi2.sf(self.kfda_statistic, self.kfda_statistic.index)
+            pval = chi2.sf(self.stat, self.stat.index)
             return pd.Series(
-                pval, index=self.kfda_statistic.index,
+                pval, index=self.stat.index,
                 dtype=str(self.dtype).replace('torch.', '')
             )
         else:
             if verbose > 0:
                 print('- Performing permutations to compute p-values:')
             stats_count = pd.Series(
-                0, index=range(1, len(self.kfda_statistic) + 1)
+                0, index=range(1, len(self.stat) + 1)
             ) if stat == 'kfda' else 0
             it = tqdm(range(n_permutations)) \
                 if verbose > 0 else range(n_permutations)
@@ -416,7 +416,7 @@ class Ktest(Statistics):
                 )
 
                 if stat == 'kfda':
-                    stats_count += perm_stats_res[0].ge(self.kfda_statistic)
+                    stats_count += perm_stats_res[0].ge(self.stat)
                 elif stat == 'mmd':
                     stats_count += (perm_stats_res >= self.mmd_statistic)
             return stats_count / n_permutations
@@ -456,7 +456,7 @@ class Ktest(Statistics):
             if stat == 'kfda':
                 if verbose > 0:
                     print('- Computing kFDA statistic')
-                self.kfda_statistic, self.kfda_statistic_contrib = \
+                self.stat, self.stat_contrib = \
                     self.compute_test_statistic(verbose=verbose)
                 if not permutation:
                     self.kfda_pval_asymp = self.compute_pvalue(verbose=verbose)
@@ -528,7 +528,7 @@ class Ktest(Statistics):
             elif verbose >= 3:
                 warnings.simplefilter("always")
 
-            if self.kfda_statistic is None:
+            if self.stat is None:
                 self.test(stat='kfda')
 
             # check new_obs input convert and to torch.Tensor
@@ -550,7 +550,7 @@ class Ktest(Statistics):
 
             # compute projections
             proj, proj_contrib = self.kstat.compute_projections(
-                self.kfda_statistic, n_trunc=n_trunc, center=center, new_obs=new_obs
+                self.stat, n_trunc=n_trunc, center=center, new_obs=new_obs
             )
 
             # record projections only when projecting training data
@@ -628,7 +628,7 @@ class Ktest(Statistics):
                 warnings.simplefilter("always")
 
             # compute statistic if needed
-            if self.kfda_statistic is None:
+            if self.stat is None:
                 self.test(stat='kfda')
 
             # check new_obs input convert and to torch.Tensor
@@ -651,7 +651,7 @@ class Ktest(Statistics):
             # compute prediction
             kfda_pred, kfda_loss, kfda_res = self.kstat.kfda_predict(
                 n_trunc=n_trunc, new_obs=new_obs, pred_threshold=pred_threshold,
-                stat=self.kfda_statistic
+                stat=self.stat
             )
 
             # output
@@ -745,7 +745,7 @@ class Ktest(Statistics):
                 ref = self.data.sample_names[0]
 
             # compute test statistics if not done
-            if self.kfda_statistic is None:
+            if self.stat is None:
                 self.test(stat='kfda')
 
             # cross-validation sub-subsampling

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -323,7 +323,7 @@ class Ktest(Statistics):
         """
         kstatistics = kstat if kstat is not None else self.kstat
         if stat == 'kfda':
-            test_res = kstatistics.compute_kfda()
+            test_res = kstatistics.compute_kfda_stat()
         elif stat == 'mmd':
             test_res = kstatistics.compute_mmd()
         else:

--- a/python/src/ktest/utils.py
+++ b/python/src/ktest/utils.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 from numbers import Integral, Number
 import warnings
 import numpy as np

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -121,14 +121,14 @@ def assert_equal_ktest():
 
         # setup truncation
         if trunc is None:
-            trunc1 = len(kt_1.kfda_statistic)
-            trunc2 = len(kt_2.kfda_statistic)
+            trunc1 = len(kt_1.stat)
+            trunc2 = len(kt_2.stat)
         else:
             trunc1 = trunc
             trunc2 = trunc
         # test statistics
         npt.assert_allclose(
-            kt_1.kfda_statistic[:trunc1], kt_2.kfda_statistic[:trunc2],
+            kt_1.stat[:trunc1], kt_2.stat[:trunc2],
             rtol=rtol, atol=atol
         )
         # asymptotic p-values

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -660,96 +660,96 @@ class TestStatistics(object):
         """Testing kFDA axis projection computation."""
         # FIXME: only result format is tested, not result values
 
-        def _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val):
+        def _check_proj(proj, proj_contrib, n_obs_val, t_val):
             """Function to check projection results on the fly."""
-            assert isinstance(proj_kfda, dict)
-            assert len(proj_kfda) == len(n_obs_val)
-            assert isinstance(proj_kpca, dict)
-            assert len(proj_kpca) == len(n_obs_val)
+            assert isinstance(proj, dict)
+            assert len(proj) == len(n_obs_val)
+            assert isinstance(proj_contrib, dict)
+            assert len(proj_contrib) == len(n_obs_val)
 
-            for proj_kfda_tab, proj_kpca_tab, n_obs in zip(
-                proj_kfda.values(), proj_kpca.values(), n_obs_val
+            for proj_tab, proj_contrib_tab, n_obs in zip(
+                proj.values(), proj_contrib.values(), n_obs_val
             ):
-                assert isinstance(proj_kfda_tab, pd.DataFrame)
-                assert proj_kfda_tab.shape == (n_obs, t_val)
-                assert isinstance(proj_kpca_tab, pd.DataFrame)
-                assert proj_kpca_tab.shape == (n_obs, t_val)
+                assert isinstance(proj_tab, pd.DataFrame)
+                assert proj_tab.shape == (n_obs, t_val)
+                assert isinstance(proj_contrib_tab, pd.DataFrame)
+                assert proj_contrib_tab.shape == (n_obs, t_val)
 
         # Case 1 - full data (no Nystrom), no centering, no new_obs
         # default: new_obs=None
         stat_val, _ = kstat.compute_kfda()
-        proj_kfda, proj_kpca = kstat.compute_projections(
+        proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=False
         )
         n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 2 - full data (no Nystrom), centering, no new_obs
         # default: new_obs=None
         stat_val, _ = kstat.compute_kfda()
-        proj_kfda, proj_kpca = kstat.compute_projections(
+        proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=True
         )
         n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 3 - full data (no Nystrom), no centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat.compute_kfda()
-        proj_kfda, proj_kpca = kstat.compute_projections(
+        proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 4 - full data (no Nystrom), centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat.compute_kfda()
-        proj_kfda, proj_kpca = kstat.compute_projections(
+        proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 5 - full data (no Nystrom), no centering, no new_obs
         # default: new_obs=None
         stat_val, _ = kstat_nystrom.compute_kfda()
-        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+        proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=False
         )
         n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 6 - full data (no Nystrom), centering, no new_obs
         # default: new_obs=None
         stat_val, _ = kstat_nystrom.compute_kfda()
-        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+        proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=True
         )
         n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 7 - full data (no Nystrom), no centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat_nystrom.compute_kfda()
-        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+        proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
         # Case 8 - full data (no Nystrom), centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat_nystrom.compute_kfda()
-        proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
+        proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
-        _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
+        _check_proj(proj, proj_contrib, n_obs_val, t_val=10)
 
     def test_kfda_loss(
         self, kstat, kstat_nystrom, ktest_separated_data,

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -626,7 +626,7 @@ class TestStatistics(object):
 
         # Case 1 - full data (no Nystrom), no new_obs
         # default: new_obs=None
-        upk = kstat.compute_upk(t=10)
+        upk = kstat.compute_upk(n_trunc=10)
 
         assert isinstance(upk, to.Tensor)
         assert upk.shape == (data_shape[0], 10)
@@ -635,14 +635,14 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
 
-        upk = kstat.compute_upk(t=10, new_obs=new_obs)
+        upk = kstat.compute_upk(n_trunc=10, new_obs=new_obs)
 
         assert isinstance(upk, to.Tensor)
         assert upk.shape == (new_obs.shape[0], 10)
 
         # Case 3 - Nystrom, no new_obs
         # default: new_obs=None
-        upk = kstat_nystrom.compute_upk(t=10)
+        upk = kstat_nystrom.compute_upk(n_trunc=10)
 
         assert isinstance(upk, to.Tensor)
         assert upk.shape == (data_shape[0], 10)
@@ -651,7 +651,7 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
 
-        upk = kstat_nystrom.compute_upk(t=10, new_obs=new_obs)
+        upk = kstat_nystrom.compute_upk(n_trunc=10, new_obs=new_obs)
 
         assert isinstance(upk, to.Tensor)
         assert upk.shape == (new_obs.shape[0], 10)
@@ -679,7 +679,7 @@ class TestStatistics(object):
         # default: new_obs=None
         stat_val, _ = kstat.compute_kfda()
         proj_kfda, proj_kpca = kstat.compute_projections(
-            stat=stat_val, t=10, center=False
+            stat=stat_val, n_trunc=10, center=False
         )
         n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -688,7 +688,7 @@ class TestStatistics(object):
         # default: new_obs=None
         stat_val, _ = kstat.compute_kfda()
         proj_kfda, proj_kpca = kstat.compute_projections(
-            stat=stat_val, t=10, center=True
+            stat=stat_val, n_trunc=10, center=True
         )
         n_obs_val = [tab.shape[0] for tab in kstat.data.data.values()]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -698,7 +698,7 @@ class TestStatistics(object):
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat.compute_kfda()
         proj_kfda, proj_kpca = kstat.compute_projections(
-            stat=stat_val, t=10, center=False, new_obs=new_obs
+            stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -708,7 +708,7 @@ class TestStatistics(object):
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat.compute_kfda()
         proj_kfda, proj_kpca = kstat.compute_projections(
-            stat=stat_val, t=10, center=True, new_obs=new_obs
+            stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -717,7 +717,7 @@ class TestStatistics(object):
         # default: new_obs=None
         stat_val, _ = kstat_nystrom.compute_kfda()
         proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
-            stat=stat_val, t=10, center=False
+            stat=stat_val, n_trunc=10, center=False
         )
         n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -726,7 +726,7 @@ class TestStatistics(object):
         # default: new_obs=None
         stat_val, _ = kstat_nystrom.compute_kfda()
         proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
-            stat=stat_val, t=10, center=True
+            stat=stat_val, n_trunc=10, center=True
         )
         n_obs_val = [tab.shape[0] for tab in kstat_nystrom.data.data.values()]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -736,7 +736,7 @@ class TestStatistics(object):
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat_nystrom.compute_kfda()
         proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
-            stat=stat_val, t=10, center=False, new_obs=new_obs
+            stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -746,7 +746,7 @@ class TestStatistics(object):
         new_obs = list(kstat_nystrom.data.data.values())[0]
         stat_val, _ = kstat_nystrom.compute_kfda()
         proj_kfda, proj_kpca = kstat_nystrom.compute_projections(
-            stat=stat_val, t=10, center=True, new_obs=new_obs
+            stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
         n_obs_val = [new_obs.shape[0]]
         _check_proj(proj_kfda, proj_kpca, n_obs_val, t_val=10)
@@ -759,7 +759,7 @@ class TestStatistics(object):
 
         # Case 1a - full data (no Nystrom), no new_obs
         # default: new_obs=None
-        dist_g1, dist_g2 = kstat.kfda_loss(t=10)
+        dist_g1, dist_g2 = kstat.kfda_loss(n_trunc=10)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -781,7 +781,7 @@ class TestStatistics(object):
         # Case 1b - full data (no Nystrom), no new_obs, providing stat value
         # default: new_obs=None
         stat_val, _ = kstat.compute_kfda()
-        dist_g1, dist_g2 = kstat.kfda_loss(t=10, stat=stat_val)
+        dist_g1, dist_g2 = kstat.kfda_loss(n_trunc=10, stat=stat_val)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -803,7 +803,7 @@ class TestStatistics(object):
         # Case 2 - full data (no Nystrom), providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
-        dist_g1, dist_g2 = kstat.kfda_loss(t=10, new_obs=new_obs)
+        dist_g1, dist_g2 = kstat.kfda_loss(n_trunc=10, new_obs=new_obs)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -824,7 +824,7 @@ class TestStatistics(object):
 
         # Case 3 - Nystrom approximation, no new_obs
         # default: new_obs=None
-        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(t=10)
+        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(n_trunc=10)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -846,7 +846,7 @@ class TestStatistics(object):
         # Case 4 - Nystrom approximation, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
-        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(t=10, new_obs=new_obs)
+        dist_g1, dist_g2 = kstat_nystrom.kfda_loss(n_trunc=10, new_obs=new_obs)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -878,7 +878,7 @@ class TestStatistics(object):
             eps=None, clip_eigval=True
         )
 
-        dist_g1, dist_g2 = kstat_sep.kfda_loss(t=10)
+        dist_g1, dist_g2 = kstat_sep.kfda_loss(n_trunc=10)
 
         assert isinstance(dist_g1, dict)
         assert isinstance(dist_g2, dict)
@@ -904,7 +904,7 @@ class TestStatistics(object):
         """Testing kFDA discriminant axis squard norm computation."""
 
         # Case 1 - full data (no Nystrom)
-        axis_norm2 = kstat.kfda_axis_norm2(t=10)
+        axis_norm2 = kstat.kfda_axis_norm2(n_trunc=10)
 
         assert isinstance(axis_norm2, to.Tensor)
         assert axis_norm2.shape == (10,)
@@ -912,14 +912,14 @@ class TestStatistics(object):
 
         # Case 2 - full data (no Nystrom), no new_obs, providing stat value
         stat_val, _ = kstat.compute_kfda()
-        axis_norm2 = kstat.kfda_axis_norm2(t=10, stat=stat_val)
+        axis_norm2 = kstat.kfda_axis_norm2(n_trunc=10, stat=stat_val)
 
         assert isinstance(axis_norm2, to.Tensor)
         assert axis_norm2.shape == (10,)
         assert axis_norm2.dtype == kstat.dtype
 
         # Case 3 - Nystrom approximation
-        axis_norm2 = kstat_nystrom.kfda_axis_norm2(t=10)
+        axis_norm2 = kstat_nystrom.kfda_axis_norm2(n_trunc=10)
 
         assert isinstance(axis_norm2, to.Tensor)
         assert axis_norm2.shape == (10,)
@@ -938,7 +938,7 @@ class TestStatistics(object):
             eps=None, clip_eigval=True
         )
 
-        axis_norm2 = kstat_sep.kfda_axis_norm2(t=10)
+        axis_norm2 = kstat_sep.kfda_axis_norm2(n_trunc=10)
 
         assert isinstance(axis_norm2, to.Tensor)
         assert axis_norm2.shape == (10,)
@@ -952,7 +952,7 @@ class TestStatistics(object):
 
         # Case 1a - full data (no Nystrom), no new_obs
         # default: new_obs=None
-        pred, loss, res = kstat.kfda_predict(t=10, pred_threshold=1/2)
+        pred, loss, res = kstat.kfda_predict(n_trunc=10, pred_threshold=1/2)
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
@@ -997,7 +997,7 @@ class TestStatistics(object):
         # default: new_obs=None
         threshold_values = np.linspace(0, 1, 11)
         pred, loss, res = kstat.kfda_predict(
-            t=10, pred_threshold=threshold_values
+            n_trunc=10, pred_threshold=threshold_values
         )
 
         assert isinstance(pred, dict)
@@ -1049,7 +1049,7 @@ class TestStatistics(object):
         # default: new_obs=None
         pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
             kstat.kfda_predict(
-                t=10, pred_threshold=1/2, extended_output=True
+                n_trunc=10, pred_threshold=1/2, extended_output=True
             )
 
         assert isinstance(pred, dict)
@@ -1124,7 +1124,7 @@ class TestStatistics(object):
         # default: new_obs=None
         pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
             kstat.kfda_predict(
-                t=10, pred_threshold=threshold_values, extended_output=True
+                n_trunc=10, pred_threshold=threshold_values, extended_output=True
             )
 
         assert isinstance(pred, dict)
@@ -1205,7 +1205,7 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
         pred, loss, res = kstat.kfda_predict(
-            t=10, new_obs=new_obs, pred_threshold=1/2
+            n_trunc=10, new_obs=new_obs, pred_threshold=1/2
         )
 
         assert isinstance(pred, dict)
@@ -1251,7 +1251,7 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
         pred, loss, res = kstat.kfda_predict(
-            t=10, new_obs=new_obs, pred_threshold=0
+            n_trunc=10, new_obs=new_obs, pred_threshold=0
         )
 
         assert isinstance(pred, dict)
@@ -1297,7 +1297,7 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat.data.data.values())[0]
         pred, loss, res = kstat.kfda_predict(
-            t=10, new_obs=new_obs, pred_threshold=1
+            n_trunc=10, new_obs=new_obs, pred_threshold=1
         )
 
         assert isinstance(pred, dict)
@@ -1342,7 +1342,7 @@ class TestStatistics(object):
         new_obs = list(kstat.data.data.values())[0]
         pred, loss, res, dist_group1, dist_group2, axis_norm2 = \
             kstat.kfda_predict(
-                t=10, new_obs=new_obs, pred_threshold=1/2, extended_output=True
+                n_trunc=10, new_obs=new_obs, pred_threshold=1/2, extended_output=True
             )
 
         assert isinstance(pred, dict)
@@ -1415,7 +1415,7 @@ class TestStatistics(object):
 
         # Case 3 - Nystrom approximation, no new_obs
         # default: new_obs=None
-        pred, loss, res = kstat_nystrom.kfda_predict(t=10, pred_threshold=1/2)
+        pred, loss, res = kstat_nystrom.kfda_predict(n_trunc=10, pred_threshold=1/2)
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)
@@ -1459,7 +1459,7 @@ class TestStatistics(object):
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
         pred, loss, res = kstat_nystrom.kfda_predict(
-            t=10, new_obs=new_obs, pred_threshold=1/2
+            n_trunc=10, new_obs=new_obs, pred_threshold=1/2
         )
 
         assert isinstance(pred, dict)
@@ -1514,7 +1514,7 @@ class TestStatistics(object):
         )
 
         # no bias in prediction, no new observations
-        pred, loss, res = kstat_sep.kfda_predict(t=50, pred_threshold=1/2)
+        pred, loss, res = kstat_sep.kfda_predict(n_trunc=50, pred_threshold=1/2)
 
         assert isinstance(pred, dict)
         assert isinstance(loss, dict)

--- a/python/tests/test_kernel_statistics.py
+++ b/python/tests/test_kernel_statistics.py
@@ -307,7 +307,7 @@ class TestStatistics(object):
         )
 
         # try to compute kfda
-        kstat.compute_kfda()
+        kstat.compute_kfda_stat()
 
     def test_compute_centering_matrix(self, kstat, kstat_nystrom):
         """Testing centering matrix computation."""
@@ -677,7 +677,7 @@ class TestStatistics(object):
 
         # Case 1 - full data (no Nystrom), no centering, no new_obs
         # default: new_obs=None
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=False
         )
@@ -686,7 +686,7 @@ class TestStatistics(object):
 
         # Case 2 - full data (no Nystrom), centering, no new_obs
         # default: new_obs=None
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=True
         )
@@ -696,7 +696,7 @@ class TestStatistics(object):
         # Case 3 - full data (no Nystrom), no centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
@@ -706,7 +706,7 @@ class TestStatistics(object):
         # Case 4 - full data (no Nystrom), centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         proj, proj_contrib = kstat.compute_projections(
             stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
@@ -715,7 +715,7 @@ class TestStatistics(object):
 
         # Case 5 - full data (no Nystrom), no centering, no new_obs
         # default: new_obs=None
-        stat_val, _ = kstat_nystrom.compute_kfda()
+        stat_val, _ = kstat_nystrom.compute_kfda_stat()
         proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=False
         )
@@ -724,7 +724,7 @@ class TestStatistics(object):
 
         # Case 6 - full data (no Nystrom), centering, no new_obs
         # default: new_obs=None
-        stat_val, _ = kstat_nystrom.compute_kfda()
+        stat_val, _ = kstat_nystrom.compute_kfda_stat()
         proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=True
         )
@@ -734,7 +734,7 @@ class TestStatistics(object):
         # Case 7 - full data (no Nystrom), no centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
-        stat_val, _ = kstat_nystrom.compute_kfda()
+        stat_val, _ = kstat_nystrom.compute_kfda_stat()
         proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
         )
@@ -744,7 +744,7 @@ class TestStatistics(object):
         # Case 8 - full data (no Nystrom), centering, providing new_obs
         # new observations: use one population subsample
         new_obs = list(kstat_nystrom.data.data.values())[0]
-        stat_val, _ = kstat_nystrom.compute_kfda()
+        stat_val, _ = kstat_nystrom.compute_kfda_stat()
         proj, proj_contrib = kstat_nystrom.compute_projections(
             stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
         )
@@ -780,7 +780,7 @@ class TestStatistics(object):
 
         # Case 1b - full data (no Nystrom), no new_obs, providing stat value
         # default: new_obs=None
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         dist_g1, dist_g2 = kstat.kfda_loss(n_trunc=10, stat=stat_val)
 
         assert isinstance(dist_g1, dict)
@@ -911,7 +911,7 @@ class TestStatistics(object):
         assert axis_norm2.dtype == kstat.dtype
 
         # Case 2 - full data (no Nystrom), no new_obs, providing stat value
-        stat_val, _ = kstat.compute_kfda()
+        stat_val, _ = kstat.compute_kfda_stat()
         axis_norm2 = kstat.kfda_axis_norm2(n_trunc=10, stat=stat_val)
 
         assert isinstance(axis_norm2, to.Tensor)

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -244,13 +244,13 @@ def test_zi_data(dummy_zidata, data_shape, nystrom):
     kt.test(verbose=0)
 
 
-def test_ktest_project(dummy_ktest):
+def test_ktest_get_projections(dummy_ktest):
     """Testing projection in Ktest class."""
     # create ktest objects
     kt = dummy_ktest()
 
     # Case 1 - centering, no new obs
-    proj, proj_contrib = kt.project(
+    proj, proj_contrib = kt.get_projections(
         n_trunc=10, center=True, verbose=1, new_obs=None
     )
 
@@ -285,7 +285,7 @@ def test_ktest_project(dummy_ktest):
         pd.testing.assert_frame_equal(proj_contrib_tab, exp_proj_contrib_tab)
 
     # Case 2 - not centering, no new obs
-    proj, proj_contrib = kt.project(
+    proj, proj_contrib = kt.get_projections(
         n_trunc=10, center=False, verbose=1, new_obs=None
     )
 
@@ -321,7 +321,7 @@ def test_ktest_project(dummy_ktest):
 
     # Case 3 - centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
-    proj, proj_contrib = kt.project(
+    proj, proj_contrib = kt.get_projections(
         n_trunc=10, center=True, verbose=1, new_obs=new_obs
     )
 
@@ -355,7 +355,7 @@ def test_ktest_project(dummy_ktest):
 
     # Case 4 - not centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
-    proj, proj_contrib = kt.project(
+    proj, proj_contrib = kt.get_projections(
         n_trunc=10, center=False, verbose=1, new_obs=new_obs
     )
 

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 import pytest
 import secrets
-import torch as t
+import torch as to
 import warnings
 
 from ktest.tester import Ktest
@@ -20,7 +20,7 @@ def dummy_ktest(dummy_data):
     Function to create Ktest object from dummy data for testing using a given
     floating point number type/precision.
     """
-    def _ktest(nystrom=False, dtype=t.float64):
+    def _ktest(nystrom=False, dtype=to.float64):
         # init object
         kt = Ktest(
             data=dummy_data[0], metadata=dummy_data[1], nystrom=nystrom,
@@ -35,7 +35,7 @@ def dummy_ktest(dummy_data):
 
 
 @pytest.mark.parametrize("nystrom", [False, True])
-@pytest.mark.parametrize("dtype", [t.float64, t.float32])
+@pytest.mark.parametrize("dtype", [to.float64, to.float32])
 def test_ktest(dummy_ktest, dummy_data, nystrom, dtype):
     """Testing Ktest class."""
     # create ktest objects
@@ -62,8 +62,8 @@ def test_ktest(dummy_ktest, dummy_data, nystrom, dtype):
 def test_ktest_precision(dummy_ktest, assert_equal_ktest):
     """Testing Ktest computing with various precision."""
     # create ktest objects (for a given precision)
-    kt_f32 = dummy_ktest(dtype=t.float32)
-    kt_f64 = dummy_ktest(dtype=t.float64)
+    kt_f32 = dummy_ktest(dtype=to.float32)
+    kt_f64 = dummy_ktest(dtype=to.float64)
 
     # check output type
     assert kt_f32.kfda_statistic.dtype == "float32"

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -55,7 +55,7 @@ def test_ktest(dummy_ktest, dummy_data, nystrom, dtype):
     pd.testing.assert_series_equal(kt.metadata, dummy_data[1])
 
     # output
-    assert isinstance(kt.kfda_statistic, pd.Series)
+    assert isinstance(kt.stat, pd.Series)
     assert isinstance(kt.kfda_pval_asymp, pd.Series)
 
 
@@ -66,15 +66,15 @@ def test_ktest_precision(dummy_ktest, assert_equal_ktest):
     kt_f64 = dummy_ktest(dtype=to.float64)
 
     # check output type
-    assert kt_f32.kfda_statistic.dtype == "float32"
+    assert kt_f32.stat.dtype == "float32"
     assert kt_f32.kfda_pval_asymp.dtype == "float32"
-    assert kt_f64.kfda_statistic.dtype == "float64"
+    assert kt_f64.stat.dtype == "float64"
     assert kt_f64.kfda_pval_asymp.dtype == "float64"
 
     # compare results
     # (tolerance threshold not too tight because of expected result differences
     # due to precision difference)
-    max_len = min([len(kt_f32.kfda_statistic), len(kt_f64.kfda_statistic)])
+    max_len = min([len(kt_f32.stat), len(kt_f64.stat)])
     npt.assert_allclose(
         kt_f32.kstat.sp.numpy()[:max_len],
         kt_f64.kstat.sp.numpy()[:max_len],
@@ -82,8 +82,8 @@ def test_ktest_precision(dummy_ktest, assert_equal_ktest):
     )
     try:
         npt.assert_allclose(
-            kt_f32.kfda_statistic.to_numpy()[:max_len],
-            kt_f64.kfda_statistic.to_numpy()[:max_len],
+            kt_f32.stat.to_numpy()[:max_len],
+            kt_f64.stat.to_numpy()[:max_len],
             rtol=0, atol=1e-3
         )
     except AssertionError as e:
@@ -177,7 +177,7 @@ def test_num_stability(kt_data, assert_equal_ktest):
     if pytest.previous_res_file is not None:
         kt_data_prev = Ktest.load(pytest.previous_res_file, compressed=True)
         assert_equal_ktest(
-            kt_data, kt_data_prev, trunc=len(kt_data.kfda_statistic), atol=1e-8
+            kt_data, kt_data_prev, trunc=len(kt_data.stat), atol=1e-8
         )
 
 

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -250,142 +250,142 @@ def test_ktest_project(dummy_ktest):
     kt = dummy_ktest()
 
     # Case 1 - centering, no new obs
-    proj_kfda, proj_kpca = kt.project(
+    proj, proj_contrib = kt.project(
         n_trunc=10, center=True, verbose=1, new_obs=None
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
-    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+    exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=True
     )
 
     # check
-    assert isinstance(proj_kfda, dict)
-    assert len(proj_kfda) == len(exp_proj_kfda)
-    assert proj_kfda.keys() == exp_proj_kfda.keys()
-    assert isinstance(proj_kpca, dict)
-    assert len(proj_kpca) == len(exp_proj_kpca)
-    assert proj_kpca.keys() == exp_proj_kpca.keys()
+    assert isinstance(proj, dict)
+    assert len(proj) == len(exp_proj)
+    assert proj.keys() == exp_proj.keys()
+    assert isinstance(proj_contrib, dict)
+    assert len(proj_contrib) == len(exp_proj_contrib)
+    assert proj_contrib.keys() == exp_proj_contrib.keys()
 
     for (
-        proj_kfda_tab, exp_proj_kfda_tab,
-        proj_kpca_tab, exp_proj_kpca_tab,
+        proj_tab, exp_proj_tab,
+        proj_contrib_tab, exp_proj_contrib_tab,
         data_tab
     ) in zip(
-        proj_kfda.values(), exp_proj_kfda.values(),
-        proj_kpca.values(), exp_proj_kpca.values(),
+        proj.values(), exp_proj.values(),
+        proj_contrib.values(), exp_proj_contrib.values(),
         kt.data.data.values()
     ):
-        assert isinstance(proj_kfda_tab, pd.DataFrame)
-        assert proj_kfda_tab.shape == (data_tab.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
-        assert isinstance(proj_kpca_tab, pd.DataFrame)
-        assert proj_kpca_tab.shape == (data_tab.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+        assert isinstance(proj_tab, pd.DataFrame)
+        assert proj_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_tab, exp_proj_tab)
+        assert isinstance(proj_contrib_tab, pd.DataFrame)
+        assert proj_contrib_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_contrib_tab, exp_proj_contrib_tab)
 
     # Case 2 - not centering, no new obs
-    proj_kfda, proj_kpca = kt.project(
+    proj, proj_contrib = kt.project(
         n_trunc=10, center=False, verbose=1, new_obs=None
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
-    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+    exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=False
     )
 
     # check
-    assert isinstance(proj_kfda, dict)
-    assert len(proj_kfda) == len(exp_proj_kfda)
-    assert proj_kfda.keys() == exp_proj_kfda.keys()
-    assert isinstance(proj_kpca, dict)
-    assert len(proj_kpca) == len(exp_proj_kpca)
-    assert proj_kpca.keys() == exp_proj_kpca.keys()
+    assert isinstance(proj, dict)
+    assert len(proj) == len(exp_proj)
+    assert proj.keys() == exp_proj.keys()
+    assert isinstance(proj_contrib, dict)
+    assert len(proj_contrib) == len(exp_proj_contrib)
+    assert proj_contrib.keys() == exp_proj_contrib.keys()
 
     for (
-        proj_kfda_tab, exp_proj_kfda_tab,
-        proj_kpca_tab, exp_proj_kpca_tab,
+        proj_tab, exp_proj_tab,
+        proj_contrib_tab, exp_proj_contrib_tab,
         data_tab
     ) in zip(
-        proj_kfda.values(), exp_proj_kfda.values(),
-        proj_kpca.values(), exp_proj_kpca.values(),
+        proj.values(), exp_proj.values(),
+        proj_contrib.values(), exp_proj_contrib.values(),
         kt.data.data.values()
     ):
-        assert isinstance(proj_kfda_tab, pd.DataFrame)
-        assert proj_kfda_tab.shape == (data_tab.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
-        assert isinstance(proj_kpca_tab, pd.DataFrame)
-        assert proj_kpca_tab.shape == (data_tab.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+        assert isinstance(proj_tab, pd.DataFrame)
+        assert proj_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_tab, exp_proj_tab)
+        assert isinstance(proj_contrib_tab, pd.DataFrame)
+        assert proj_contrib_tab.shape == (data_tab.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_contrib_tab, exp_proj_contrib_tab)
 
     # Case 3 - centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
-    proj_kfda, proj_kpca = kt.project(
+    proj, proj_contrib = kt.project(
         n_trunc=10, center=True, verbose=1, new_obs=new_obs
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
-    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+    exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
     )
 
     # check
-    assert isinstance(proj_kfda, dict)
-    assert len(proj_kfda) == len(exp_proj_kfda)
-    assert proj_kfda.keys() == exp_proj_kfda.keys()
-    assert isinstance(proj_kpca, dict)
-    assert len(proj_kpca) == len(exp_proj_kpca)
-    assert proj_kpca.keys() == exp_proj_kpca.keys()
+    assert isinstance(proj, dict)
+    assert len(proj) == len(exp_proj)
+    assert proj.keys() == exp_proj.keys()
+    assert isinstance(proj_contrib, dict)
+    assert len(proj_contrib) == len(exp_proj_contrib)
+    assert proj_contrib.keys() == exp_proj_contrib.keys()
 
     for (
-        proj_kfda_tab, exp_proj_kfda_tab,
-        proj_kpca_tab, exp_proj_kpca_tab
+        proj_tab, exp_proj_tab,
+        proj_contrib_tab, exp_proj_contrib_tab
     ) in zip(
-        proj_kfda.values(), exp_proj_kfda.values(),
-        proj_kpca.values(), exp_proj_kpca.values()
+        proj.values(), exp_proj.values(),
+        proj_contrib.values(), exp_proj_contrib.values()
     ):
-        assert isinstance(proj_kfda_tab, pd.DataFrame)
-        assert proj_kfda_tab.shape == (new_obs.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
-        assert isinstance(proj_kpca_tab, pd.DataFrame)
-        assert proj_kpca_tab.shape == (new_obs.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+        assert isinstance(proj_tab, pd.DataFrame)
+        assert proj_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_tab, exp_proj_tab)
+        assert isinstance(proj_contrib_tab, pd.DataFrame)
+        assert proj_contrib_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_contrib_tab, exp_proj_contrib_tab)
 
     # Case 4 - not centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
-    proj_kfda, proj_kpca = kt.project(
+    proj, proj_contrib = kt.project(
         n_trunc=10, center=False, verbose=1, new_obs=new_obs
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
-    exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
+    exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
     )
 
     # check
-    assert isinstance(proj_kfda, dict)
-    assert len(proj_kfda) == len(exp_proj_kfda)
-    assert proj_kfda.keys() == exp_proj_kfda.keys()
-    assert isinstance(proj_kpca, dict)
-    assert len(proj_kpca) == len(exp_proj_kpca)
-    assert proj_kpca.keys() == exp_proj_kpca.keys()
+    assert isinstance(proj, dict)
+    assert len(proj) == len(exp_proj)
+    assert proj.keys() == exp_proj.keys()
+    assert isinstance(proj_contrib, dict)
+    assert len(proj_contrib) == len(exp_proj_contrib)
+    assert proj_contrib.keys() == exp_proj_contrib.keys()
 
     for (
-        proj_kfda_tab, exp_proj_kfda_tab,
-        proj_kpca_tab, exp_proj_kpca_tab
+        proj_tab, exp_proj_tab,
+        proj_contrib_tab, exp_proj_contrib_tab
     ) in zip(
-        proj_kfda.values(), exp_proj_kfda.values(),
-        proj_kpca.values(), exp_proj_kpca.values()
+        proj.values(), exp_proj.values(),
+        proj_contrib.values(), exp_proj_contrib.values()
     ):
-        assert isinstance(proj_kfda_tab, pd.DataFrame)
-        assert proj_kfda_tab.shape == (new_obs.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kfda_tab, exp_proj_kfda_tab)
-        assert isinstance(proj_kpca_tab, pd.DataFrame)
-        assert proj_kpca_tab.shape == (new_obs.shape[0], 10)
-        pd.testing.assert_frame_equal(proj_kpca_tab, exp_proj_kpca_tab)
+        assert isinstance(proj_tab, pd.DataFrame)
+        assert proj_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_tab, exp_proj_tab)
+        assert isinstance(proj_contrib_tab, pd.DataFrame)
+        assert proj_contrib_tab.shape == (new_obs.shape[0], 10)
+        pd.testing.assert_frame_equal(proj_contrib_tab, exp_proj_contrib_tab)
 
 
 def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -56,7 +56,7 @@ def test_ktest(dummy_ktest, dummy_data, nystrom, dtype):
 
     # output
     assert isinstance(kt.stat, pd.Series)
-    assert isinstance(kt.kfda_pval_asymp, pd.Series)
+    assert isinstance(kt.pval, pd.Series)
 
 
 def test_ktest_precision(dummy_ktest, assert_equal_ktest):

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -255,7 +255,7 @@ def test_ktest_get_projections(dummy_ktest):
     )
 
     # expected results
-    stat_val, _ = kt.kstat.compute_kfda()
+    stat_val, _ = kt.kstat.compute_kfda_stat()
     exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=True
     )
@@ -290,7 +290,7 @@ def test_ktest_get_projections(dummy_ktest):
     )
 
     # expected results
-    stat_val, _ = kt.kstat.compute_kfda()
+    stat_val, _ = kt.kstat.compute_kfda_stat()
     exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=False
     )
@@ -326,7 +326,7 @@ def test_ktest_get_projections(dummy_ktest):
     )
 
     # expected results
-    stat_val, _ = kt.kstat.compute_kfda()
+    stat_val, _ = kt.kstat.compute_kfda_stat()
     exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
     )
@@ -360,7 +360,7 @@ def test_ktest_get_projections(dummy_ktest):
     )
 
     # expected results
-    stat_val, _ = kt.kstat.compute_kfda()
+    stat_val, _ = kt.kstat.compute_kfda_stat()
     exp_proj, exp_proj_contrib = kt.kstat.compute_projections(
         stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
     )

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -251,13 +251,13 @@ def test_ktest_project(dummy_ktest):
 
     # Case 1 - centering, no new obs
     proj_kfda, proj_kpca = kt.project(
-        t=10, center=True, verbose=1, new_obs=None
+        n_trunc=10, center=True, verbose=1, new_obs=None
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
     exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
-        stat=stat_val, t=10, center=True
+        stat=stat_val, n_trunc=10, center=True
     )
 
     # check
@@ -286,13 +286,13 @@ def test_ktest_project(dummy_ktest):
 
     # Case 2 - not centering, no new obs
     proj_kfda, proj_kpca = kt.project(
-        t=10, center=False, verbose=1, new_obs=None
+        n_trunc=10, center=False, verbose=1, new_obs=None
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
     exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
-        stat=stat_val, t=10, center=False
+        stat=stat_val, n_trunc=10, center=False
     )
 
     # check
@@ -322,13 +322,13 @@ def test_ktest_project(dummy_ktest):
     # Case 3 - centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
     proj_kfda, proj_kpca = kt.project(
-        t=10, center=True, verbose=1, new_obs=new_obs
+        n_trunc=10, center=True, verbose=1, new_obs=new_obs
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
     exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
-        stat=stat_val, t=10, center=True, new_obs=new_obs
+        stat=stat_val, n_trunc=10, center=True, new_obs=new_obs
     )
 
     # check
@@ -356,13 +356,13 @@ def test_ktest_project(dummy_ktest):
     # Case 4 - not centering, providing new obs
     new_obs = list(kt.kstat.data.data.values())[0]
     proj_kfda, proj_kpca = kt.project(
-        t=10, center=False, verbose=1, new_obs=new_obs
+        n_trunc=10, center=False, verbose=1, new_obs=new_obs
     )
 
     # expected results
     stat_val, _ = kt.kstat.compute_kfda()
     exp_proj_kfda, exp_proj_kpca = kt.kstat.compute_projections(
-        stat=stat_val, t=10, center=False, new_obs=new_obs
+        stat=stat_val, n_trunc=10, center=False, new_obs=new_obs
     )
 
     # check
@@ -400,7 +400,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=None, pred_threshold=0.5, verbose=1
+        n_trunc=10, new_obs=None, pred_threshold=0.5, verbose=1
     )
 
     # check
@@ -452,7 +452,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=None, pred_threshold=threshold_values, verbose=1
+        n_trunc=10, new_obs=None, pred_threshold=threshold_values, verbose=1
     )
 
     # check
@@ -512,7 +512,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=new_obs, pred_threshold=0.5, verbose=1
+        n_trunc=10, new_obs=new_obs, pred_threshold=0.5, verbose=1
     )
 
     # check
@@ -566,7 +566,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=new_obs, pred_threshold=0, verbose=1
+        n_trunc=10, new_obs=new_obs, pred_threshold=0, verbose=1
     )
 
     # check
@@ -620,7 +620,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=new_obs, pred_threshold=1, verbose=1
+        n_trunc=10, new_obs=new_obs, pred_threshold=1, verbose=1
     )
 
     # check
@@ -670,7 +670,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=None, pred_threshold=0.5, verbose=1
+        n_trunc=10, new_obs=None, pred_threshold=0.5, verbose=1
     )
 
     # check
@@ -723,7 +723,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=10, new_obs=new_obs, pred_threshold=1/2, verbose=1
+        n_trunc=10, new_obs=new_obs, pred_threshold=1/2, verbose=1
     )
 
     # check
@@ -776,7 +776,7 @@ def test_ktest_predict(dummy_ktest, dummy_separated_data, capsys):
 
     # run CV
     pred, loss, res = kt.predict(
-        t=50, new_obs=None, pred_threshold=1/2, verbose=1
+        n_trunc=50, new_obs=None, pred_threshold=1/2, verbose=1
     )
 
     # check
@@ -831,7 +831,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
     # run CV
     accuracy, true_pos, true_neg, residuals = kt.cv(
-        t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
+        n_trunc=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
         random_state=None, verbose=1
     )
     # check stdout (expect output)
@@ -880,7 +880,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
     # run CV
     accuracy, true_pos, true_neg, residuals = kt.cv(
-        t=50, pred_threshold=1, n_fold=5, n_repeat=1,
+        n_trunc=50, pred_threshold=1, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
 
@@ -928,7 +928,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     kt = dummy_ktest()
     # run CV
     accuracy, true_pos, true_neg, residuals = kt.cv(
-        t=50, pred_threshold=0, n_fold=5, n_repeat=1,
+        n_trunc=50, pred_threshold=0, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
 
@@ -972,7 +972,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     # run CV
     threshold_values = np.linspace(0, 1, 11)
     accuracy, true_pos, true_neg, residuals = kt.cv(
-        t=50, pred_threshold=threshold_values, n_fold=5, n_repeat=1,
+        n_trunc=50, pred_threshold=threshold_values, n_fold=5, n_repeat=1,
         random_state=None, verbose=0
     )
     # check output
@@ -1020,7 +1020,7 @@ def test_ktest_cv(dummy_ktest, dummy_separated_data, capsys):
     )
     # run CV
     accuracy, true_pos, true_neg, residuals = kt.cv(
-        t=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
+        n_trunc=50, pred_threshold=1/2, n_fold=5, n_repeat=1,
         random_state=None, verbose=1
     )
 


### PR DESCRIPTION
- The number of truncations `t` becomes `n_trunc`
- `proj_kfda` and `kfda_proj` attributes or variables becomes `proj`, similarly `proj_kpca` and `fda_proj_contrib` becomes `proj_contrib`
- `Ktest.project()` method becomes `Ktest.get_projections()`
- `Statistics.compute_kfda()` method becomes `Statistics.compute_kfda_stat()`
- `Ktest.kfda_statistic` attribute becomes `Ktest.stat`
- A new `Ktest.pval` attribute stores the latest computed p-values (either asymptotically or with permutation)
- other minor modifications