### PR TITLE
Fix package install on MacOS with x86 processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Latest development version:
 pip install ktest@git+https://github.com/LMJL-Alea/ktest@main#subdirectory=python
 ```
 
+> **Caution:** For users of MacOS with x86 processors (before Apple switched to ARM processors), PyTorch (that is a dependency for `ktest`) stopped supporting this platform with version 2.3. As a consequence, you will be limited to Pytorch `<2.3`, and thus Python `>=3.8,<3.13`.
+
 ### Tutorials
 
 See the dedicated [`tutorials`](https://github.com/LMJL-Alea/ktest/tree/main/tutorials) folder in the project root directory for notebook tutorials in Python.

--- a/python/README.md
+++ b/python/README.md
@@ -28,6 +28,8 @@ Latest development version:
 pip install ktest@git+https://github.com/LMJL-Alea/ktest@main#subdirectory=python
 ```
 
+> **Caution:** For users of MacOS with x86 processors (before Apple switched to ARM processors), PyTorch (that is a dependency for `ktest`) stopped supporting this platform with version 2.3. As a consequence, you will be limited to Pytorch `<2.3`, and thus Python `>=3.8,<3.13`.
+
 ### Tutorials
 
 See the dedicated [`tutorials`](https://github.com/LMJL-Alea/ktest/tree/main/tutorials) folder in the project root directory for notebook tutorials.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ktest"
-version = "1.3.1"
+version = "1.3.2"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
-requires = [
-    "setuptools>=72.1.0"
-]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling >= 1.26"]
+build-backend = "hatchling.build"
 
 [project]
 name = "ktest"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,11 +17,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
-    "torch>=2.2.0; sys_platform != 'darwin'",
-    "torch>=2.2.0; sys_platform == 'darwin' and platform_machine != 'x86_64'",
-    "torch>=2.2.0,<2.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    # Default torch dependency for Linux and macOS ARM
+    "torch>=2.2; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    # macOS x86: torch < 2.3 (hence Python < 3.13)
+    "torch>=2.2,<2.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "numpy",
     "scipy",
     "scikit-learn",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,3 +65,14 @@ exclude = [
 [tool.hatch.build.targets.wheel]
 only-packages = true
 
+[tool.uv]
+environments = [
+    # Linux
+    "sys_platform == 'linux'",
+    # MacOS arm
+    "sys_platform == 'darwin' and platform_machine != 'x86_64'",
+    # MacOS x86
+    "sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    # Windows (not tested)
+    "sys_platform == 'win32'"
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,19 +35,6 @@ dependencies = [
     "natsort>=8.2.0",
 ]
 
-[project.readme]
-file = "README.md"
-content-type = "text/markdown"
-
-[project.urls]
-Homepage = "https://github.com/LMJL-Alea/ktest.git"
-"Bug Tracker" = "https://github.com/LMJL-Alea/ktest/issues"
-
-[tool.setuptools]
-package-dir = {"" = "src"}
-packages = ["ktest"]
-include-package-data = false
-
 [dependency-groups]
 dev = [
     "ipython>=7.16.3",
@@ -56,3 +43,24 @@ dev = [
     "seaborn>=0.11.2",
     "toml>=0.10.2",
 ]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.urls]
+Homepage = "https://github.com/LMJL-Alea/ktest.git"
+"Bug Tracker" = "https://github.com/LMJL-Alea/ktest/issues"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/ktest"
+]
+exclude = [
+    "/dev",
+    "/fig"
+]
+
+[tool.hatch.build.targets.wheel]
+only-packages = true
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,9 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
-    "torch",
+    "torch>=2.2.0; sys_platform != 'darwin'",
+    "torch>=2.2.0; sys_platform == 'darwin' and platform_machine != 'x86_64'",
+    "torch>=2.2.0,<2.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "numpy",
     "scipy",
     "scikit-learn",


### PR DESCRIPTION
Issue when installing `torch` on MacOS with x86 processor. Support for such combination of OS and hardware have been stopped at v2.3+

Work in progress