### PR TITLE
Quick follow-up on fixing and simplifying variable and parameter names

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ktest"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
     {name = "Anthony Ozier-Lafontaine", email = "anthony.ozier-lafontaine@ec-nantes.fr"},
     {name = "Polina Arsenteva", email = "polina.arsenteva@ens-lyon.fr"},

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -879,7 +879,7 @@ class Ktest(Statistics):
             return accuracy, true_pos, true_neg, residuals
 
     def plot_density(
-        self, t=None, t_max=100, colors=None, labels=None, alpha=.5,
+        self, trunc=None, trunc_max=100, colors=None, labels=None, alpha=.5,
         legend_fontsize=15, font_family='serif'
     ):
         """
@@ -888,10 +888,10 @@ class Ktest(Statistics):
 
         Parameters
         ----------
-        t : int, optional
+        trunc : int, optional
             Axis to plot, by default equal to the maximal truncation.
 
-        t_max : int, optional
+        trunc_max : int, optional
             Maximal truncation for projections calculation, the default is 100.
 
         colors : dict or None
@@ -917,6 +917,9 @@ class Ktest(Statistics):
             'cursive'), the default is 'serif'.
 
         """
+        t = trunc
+        t_max = trunc_max
+
         if t is None:
             t = min(t_max, len(self.kstat.sp))
         if t > len(self.kstat.sp):
@@ -959,8 +962,8 @@ class Ktest(Statistics):
         return fig, ax
 
     def scatter_projection(
-        self, t_x=1, t_y=2, proj_xy=['kfda', 'kfda_contrib'],
-        t_max=100, colors=None, labels=None, alpha=.75,
+        self, trunc_x=1, trunc_y=2, proj_xy=['kfda', 'kfda_contrib'],
+        trunc_max=100, colors=None, labels=None, alpha=.75,
         legend_fontsize=15, font_family='serif'
     ):
         """
@@ -970,15 +973,15 @@ class Ktest(Statistics):
 
         Parameters
         ----------
-        t_x : int, optional
+        trunc_x : int, optional
             Axis for the scatter with respect to axis x,
             the default is 1.
 
-        t_y : int, optional
+        trunc_y : int, optional
             Axis for the scatter with respect to axis y,
             the default is 1.
 
-        t_max : int, optional
+        trunc_max : int, optional
             Maximal truncation for projections calculation, the default is 100.
 
         proj_xy : pair of strings, optional
@@ -1011,6 +1014,10 @@ class Ktest(Statistics):
             'cursive'), the default is 'serif'.
 
         """
+        t_x = trunc_x
+        t_y = trunc_y
+        t_max = trunc_max
+
         max_t_xy = max(t_x, t_y)
         if max_t_xy > len(self.kstat.sp):
             raise ValueError(

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -271,26 +271,27 @@ class Ktest(Statistics):
             s += f" {self.data_nystrom.ntot} landmarks."
 
         s += '\n___Multivariate test results___'
-        ncs = 'not computed, run ktest.test.'
-        mmd_s = f'{self.mmd_statistic}, pvalue' + \
-            f'(permutation test): {self.mmd_pval_perm}.'
-        s += '\nMMD:\n'
-        s += f'{mmd_s}' if self.mmd_statistic is not None else ncs
-        s += '\nkFDA:'
-        if self.stat is None:
-            s += '\n' + ncs
+        ncs = 'not computed, run ktest.test().'
+        if self.stat_type == 'mmd':
+            mmd_s = f'stat={self.stat}, P-value={self.pval} (permutation)'
+            s += '\nMMD: '
+            s += f'{mmd_s}' if self.stat is not None else ncs
+        elif self.stat_type == 'kfda':
+            s += '\nkFDA:'
+            if self.stat is None:
+                s += '\n' + ncs
+            else:
+                for t in range(min(len(self.stat), 5)):
+                    s += f'\nTruncation {t+1}: stat={self.stat.iloc[t]}, '
+                    s += 'P-value='
+                    s += f'{self.pval.iloc[t]}' if self.pval is not None else \
+                        'not computed'
+                    s += ' ('
+                    s += 'asymptotic' if self.pval_type == "asymp" \
+                        else "permuation"
+                    s += ')'
         else:
-            for t in range(min(len(self.stat), 5)):
-                s += f'\nTruncation {t+1}: {self.stat.iloc[t]}. '
-                s += 'P-value:\n'
-                s += 'asymptotic: '
-                s += (f'{self.kfda_pval_asymp.iloc[t]}'
-                      if self.kfda_pval_asymp is not None else 'not computed')
-                s += ', '
-                s += 'permutation: '
-                s += (f'{self.kfda_pval_perm.iloc[t]}'
-                      if self.kfda_pval_perm is not None else 'not computed')
-                s += '.'
+            s += '\n' + ncs
         return s
 
     def __repr__(self):

--- a/python/src/ktest/tester.py
+++ b/python/src/ktest/tester.py
@@ -115,53 +115,49 @@ class Ktest(Statistics):
 
         kstat : instance of class Statistics
             Attribute used for statistics calculation, see the documentation
-            of the class Statistics for more details.
+            of the class `ktest.kernel_statistics.Statistics` for more details.
 
         data_nystrom : None or instance of class Data
             None if nystrom==False. Otherwise, contains various information on
             the Nystrom dataset, see the documentation of the class Data
             for more details.
 
-        stat : Pandas.Series or None
-            None if not computed. Otherwise, stores the computed kFDA
-            statistics. Indices correspond to truncations.
+        stat : Pandas.Series or float or None
+            Computed kFDA test statistic values (`Pandas.Series`)
+            corresponding to increasing truncation values,
+            or MMD test statistic value (float) if specifically requested.
+            None if not computed.
 
-        pval : Pandas.Series or None
-            None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'stat'), obtained
-            from the asymptotic distribution (chi-square with T degree of
-            freedom) or with a permutation approach (if requested).
-            Indices correspond to truncations.
+        stat_type : str
+            Type of statistics that was computed, either `"kfda"` (default) for
+            kernel FDA-based 2 sample test or `"mmd"` for maximum mean
+            discrepancy-based test.
+            `None` if statistics values have not been computed yet.
+
+        pval : Pandas.Series or float or None
+            Computed p-values (`Pandas.Series`) associated to the kFDA test
+            statistic values, corresponding to increasing truncation values,
+            obtained from the asymptotic distribution (chi-square with T degree
+            of freedom) or with a permutation approach,
+            or p-value (float) associated to the MMD test statistic value,
+            obtained with a permutation approach.
+            None if not computed.
 
         stat_contrib : Pandas.Series or None
-            None if not computed. Otherwise, stores the unidirectional
-            statistic associated with each eigendirection of the within-group
-            covariance operator. `stat` contains the cumulated sum
-            of the values in `kfda_contributions`. Indices correspond to
-            truncations.
+            Unidirectional statistic associated with each eigendirection of
+            the within-group covariance operator for the kFDA statistics,
+            corresponding to increasing truncation values.
+            For kFDA, `self.stat` contains the cumulated sum of the values in
+            `self.stat_contrib`.
+            This quantity is irrelevant for MMD test statistics (see
+            `self.stat_type`).
 
-        kfda_pval_asymp : Pandas.Series or None
-            None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'stat'), obtained
-            from the asymptotic distribution (chi-square with T degree of
-            freedom). Indices correspond to truncations.
-            Note for dev: kept for legacy purpose only.
-
-        kfda_pval_perm  : Pandas.Series or None
-            None if not computed. Otherwise, stores the p-values associated
-            with the kFDA statistic (stored in 'stat'), obtained
-            with a permutation approach. Indices correspond to truncations.
-            Note for dev: kept for legacy purpose only.
-
-        mmd_statistic : float or None
-            None if not computed. Otherwise, stores the MMD test statistics.
-            Note for dev: kept for legacy purpose only.
-
-        mmd_pval_perm : float or None
-            None if not computed. Otherwise, stores the p-values
-            associated with each MMD statistic (only the permutation approach
-            is considered for MMD).
-            Note for dev: kept for legacy purpose only.
+        pval_type : str
+            Type of p-values that have been computed, can be `"asymp"` for
+            "asymptotic" or `"perm"` for permutation. C.f.
+            `self.pval` attribute doc. `None` if p-values have not been
+            computed yet. Note: for MMD test statistics, p-values can only
+            be estimated by permutations.
 
         proj : pandas.DataFrame
             Projections of the embeddings on the discriminant axis
@@ -256,16 +252,12 @@ class Ktest(Statistics):
             )
 
             ### Output statistics ###
-            ## kFDA statistic
+            ## kFDA (or MMD) statistic
             self.stat = None
+            self.stat_type = None
             self.pval = None
-            self.kfda_pval_asymp = None
-            self.kfda_pval_perm = None
+            self.pval_type = None
             self.stat_contrib = None
-
-            ## MMD statistic
-            self.mmd_statistic = None
-            self.mmd_pval_perm = None
 
             ### Projections:
             self.proj = {}
@@ -430,7 +422,7 @@ class Ktest(Statistics):
                 if stat == 'kfda':
                     stats_count += perm_stats_res[0].ge(self.stat)
                 elif stat == 'mmd':
-                    stats_count += (perm_stats_res >= self.mmd_statistic)
+                    stats_count += (perm_stats_res >= self.stat)
             return stats_count / n_permutations
 
     def test(
@@ -471,29 +463,31 @@ class Ktest(Statistics):
                 self.stat, self.stat_contrib = \
                     self.compute_test_statistic(verbose=verbose)
                 if not permutation:
-                    self.kfda_pval_asymp = self.compute_pvalue(verbose=verbose)
-                    self.pval = self.kfda_pval_asymp
+                    self.pval = self.compute_pvalue(verbose=verbose)
+                    self.pval_type = "asymp"
                 else:
-                    self.kfda_pval_perm = self.compute_pvalue(
+                    self.pval = self.compute_pvalue(
                         permutation=permutation, n_permutations=n_permutations,
                         verbose=verbose
                     )
-                    self.pval = self.kfda_pval_perm
+                    self.pval_type = "perm"
             elif stat == 'mmd':
                 if verbose > 0:
                     print('- Computing MMD statistic')
-                self.mmd_statistic = self.compute_test_statistic(
+                self.stat = self.compute_test_statistic(
                     stat=stat, verbose=verbose
                 )
-                self.mmd_pval_perm = self.compute_pvalue(
+                self.pval = self.compute_pvalue(
                     stat=stat, verbose=verbose, n_permutations=n_permutations
                 )
-                self.pval = self.mmd_pval_perm
+                self.pval_type = "perm"
             else:
                 raise ValueError(
                     f"Statistic '{stat}' not recognized. " +
                     "Possible values : 'kfda','mmd'"
                 )
+
+            self.stat_type = stat
 
     def get_projections(self, n_trunc=100, center=True, new_obs=None, verbose=1):
         """

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -133,7 +133,7 @@ def assert_equal_ktest():
         )
         # asymptotic p-values
         npt.assert_allclose(
-            kt_1.kfda_pval_asymp[:trunc1], kt_2.kfda_pval_asymp[:trunc2],
+            kt_1.pval[:trunc1], kt_2.pval[:trunc2],
             rtol=rtol, atol=atol
         )
 

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -67,9 +67,9 @@ def test_ktest_precision(dummy_ktest, assert_equal_ktest):
 
     # check output type
     assert kt_f32.stat.dtype == "float32"
-    assert kt_f32.kfda_pval_asymp.dtype == "float32"
+    assert kt_f32.pval.dtype == "float32"
     assert kt_f64.stat.dtype == "float64"
-    assert kt_f64.kfda_pval_asymp.dtype == "float64"
+    assert kt_f64.pval.dtype == "float64"
 
     # compare results
     # (tolerance threshold not too tight because of expected result differences
@@ -92,8 +92,8 @@ def test_ktest_precision(dummy_ktest, assert_equal_ktest):
         warnings.warn(e)
     try:
         npt.assert_allclose(
-            kt_f32.kfda_pval_asymp.to_numpy()[:max_len],
-            kt_f64.kfda_pval_asymp.to_numpy()[:max_len],
+            kt_f32.pval.to_numpy()[:max_len],
+            kt_f64.pval.to_numpy()[:max_len],
             rtol=0, atol=1e-5
         )
     except AssertionError as e:

--- a/python/tests/test_tester.py
+++ b/python/tests/test_tester.py
@@ -189,7 +189,7 @@ def test_constant_var(dummy_data, data_shape, nystrom):
     data, metadata = dummy_data
 
     # insert one constant column in data
-    data[data.columns[0]].values[:] = 0
+    data.loc[:, data.columns[0]] = 0
 
     # init object
     kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
@@ -198,16 +198,7 @@ def test_constant_var(dummy_data, data_shape, nystrom):
 
     # insert constant columns in data (except final one)
     for col in data.columns[:99]:
-        data[col].values[:] = 0
-
-    # init object
-    kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
-    # run kfda test
-    kt.test(verbose=0)
-
-    # insert constant columns in data (except final one)
-    for col in data.columns[:99]:
-        data[col].values[:] = 0
+        data.loc[:, col] = 0
 
     # init object
     kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
@@ -215,7 +206,7 @@ def test_constant_var(dummy_data, data_shape, nystrom):
     kt.test(verbose=0)
 
     # insert constant columns in final column (in one group only)
-    data[data.columns[99]].values[::2] = 0
+    data.loc[::2, data.columns[99]] = 0
 
     # init object
     kt = Ktest(data=data, metadata=metadata, nystrom=nystrom)
@@ -223,7 +214,7 @@ def test_constant_var(dummy_data, data_shape, nystrom):
     kt.test(verbose=0)
 
     # insert constant columns in final column (in all groups)
-    data[data.columns[99]].values[:] = 0
+    data.loc[:, data.columns[99]] = 0
 
     err_msg = "All variables have constant values in your data."
     with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
Detailed list of modification:

* 83f2f77 bump package version: 1.3.2 -> 1.3.3 (follow up on simplifying variable and parameter names + minor fix)
* ca4d2b2 rename 't' by 'trunc' in signature of plot functions (NOTE: plot function implementations have not been reimplemeted with matching between old and new input parameter names with local variables)
* 26e1de5 refactor Ktest object printing to account for simplified stat/pval organization
* c3b8425 simplify Ktest object attributes: only a single 'stat' attribute for test statistic and 'pval' attribute for corresponding p-values, remove any specific attribute for 'kfda' vs 'mmd' test and 'asymptotic' vs 'permutation' p-values, replaced by 'stat_type' and 'pval_type' attributes
* 9218103 fix Ktest class unit tests: make then compatible with Pandas 3+ (in place value modification mechanism changed) + remove duplicated code